### PR TITLE
Extend JWT timeout to be less zealous

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -181,8 +181,9 @@ AUTHENTICATION_BACKENDS = (
 )
 
 JWT_AUTH = {
-    'JWT_EXPIRATION_DELTA': datetime.timedelta(minutes=60),
+    'JWT_EXPIRATION_DELTA': datetime.timedelta(days=2),
     'JWT_ALLOW_REFRESH': True,
+    'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
     'JWT_AUTH_HEADER_PREFIX': 'Bearer',
 }
 


### PR DESCRIPTION
Change JWT expiry timeouts to allow for users to stay logged in over a
longer time than previously possible. The idea with these settings is to
allow for the following use cases:

* User doesn't get logged out during daily use
* User only needs to log in once per week
* A user is still logged after a free day during the week

These timeouts where set in this fashion with usability being the
primary aim. Due to the data expected in the system more strict security
settings are not a consideration.