### PR TITLE
Added "my_most_frequent" filter to task end point

### DIFF
--- a/timed/projects/filters.py
+++ b/timed/projects/filters.py
@@ -44,7 +44,7 @@ class MyMostFrequentTaskFilter(Filter):
         for today's usage.
 
         :param QuerySet qs: The queryset to filter
-        :param int   value: number of frequest items
+        :param int   value: number of most frequent items
         :return:            The filtered queryset
         :rtype:             QuerySet
         """
@@ -53,6 +53,7 @@ class MyMostFrequentTaskFilter(Filter):
 
         qs = qs.filter(reports__user=user, reports__date__gt=from_date)
         qs = qs.annotate(frequency=Count('reports')).order_by('-frequency')
+        # limit number of results to given value
         qs = qs[:int(value)]
 
         return qs

--- a/timed/projects/filters.py
+++ b/timed/projects/filters.py
@@ -1,6 +1,8 @@
 """Filters for filtering the data of the projects app endpoints."""
+from datetime import date, timedelta
 
-from django_filters import FilterSet
+from django.db.models import Count
+from django_filters import Filter, FilterSet
 
 from timed.projects import models
 
@@ -25,11 +27,38 @@ class ProjectFilterSet(FilterSet):
         fields = ['archived', 'customer']
 
 
+class MyMostFrequentTaskFilter(Filter):
+    """Filter most frequently used tasks."""
+
+    def filter(self, qs, value):
+        """Filter for given most frequently used tasks.
+
+        Most frequently used tasks are only counted within last
+        few months as older tasks are not relevant anymore
+        for today's usage.
+
+        :param QuerySet qs: The queryset to filter
+        :param int   value: number of frequest items
+        :return:            The filtered queryset
+        :rtype:             QuerySet
+        """
+        user = self.parent.request.user
+        from_date = date.today() - timedelta(days=60)
+
+        qs = qs.filter(reports__user=user, reports__date__gt=from_date)
+        qs = qs.annotate(frequency=Count('reports')).order_by('-frequency')
+        qs = qs[:int(value)]
+
+        return qs
+
+
 class TaskFilterSet(FilterSet):
     """Filter set for the tasks endpoint."""
+
+    my_most_frequent = MyMostFrequentTaskFilter()
 
     class Meta:
         """Meta information for the task filter set."""
 
         model  = models.Task
-        fields = ['archived', 'project']
+        fields = ['archived', 'project', 'my_most_frequent']

--- a/timed/projects/filters.py
+++ b/timed/projects/filters.py
@@ -28,7 +28,13 @@ class ProjectFilterSet(FilterSet):
 
 
 class MyMostFrequentTaskFilter(Filter):
-    """Filter most frequently used tasks."""
+    """Filter most frequently used tasks.
+
+    TODO:
+    From an api and framework standpoint instead of an additional filter it
+    would be more desirable to assign an ordering field frecency and to
+    limit by use paging.  This is way harder to implement therefore on hold.
+    """
 
     def filter(self, qs, value):
         """Filter for given most frequently used tasks.

--- a/timed/projects/views.py
+++ b/timed/projects/views.py
@@ -68,6 +68,7 @@ class TaskViewSet(ReadOnlyModelViewSet):
         """Specific filter queryset options."""
         # my most frequent filter uses LIMIT so default ordering
         # needs to be disabled to avoid exception
+        # see TODO filters.MyMostFrequentTaskFilter to avoid this
         if 'my_most_frequent' in self.request.query_params:
             self.ordering = None
 

--- a/timed/projects/views.py
+++ b/timed/projects/views.py
@@ -63,3 +63,12 @@ class TaskViewSet(ReadOnlyModelViewSet):
         ).filter(
             archived=False
         )
+
+    def filter_queryset(self, queryset):
+        """Specific filter queryset options."""
+        # my most frequent filter uses LIMIT so default ordering
+        # needs to be disabled to avoid exception
+        if 'my_most_frequent' in self.request.query_params:
+            self.ordering = None
+
+        return super().filter_queryset(queryset)


### PR DESCRIPTION
It only counts most frequent tasks of user which have been reported to in the last few months as only those are relevant for usability. Filter expects an integer of how may tasks need to be given.

This supersedes #22. 