### PR TITLE
Remove jet and crispy forms dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 django>=1.11,<1.12
 django-auth-ldap==1.2.11
-django-crispy-forms==1.6.1
 django-filter==1.0.2
-django-jet==1.0.6
 django-multiselectfield==0.1.6
 djangorestframework>=3.6,<3.7
 djangorestframework-jsonapi==2.2.0

--- a/timed/models.py
+++ b/timed/models.py
@@ -9,8 +9,6 @@ class WeekdaysField(MultiSelectField):
 
     Stores weekdays as comma-separated values in database as
     iso week day (MON = 1, SUN = 7).
-    For django-jet to properly show multiple choices in admin
-    it is necessary to overwrite checkbox_option.html template.
     """
 
     MO, TU, WE, TH, FR, SA, SU = range(1, 8)

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -30,7 +30,6 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
-    'jet',
     'django.contrib.admin',
     'multiselectfield',
     'django.forms',
@@ -40,7 +39,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
-    'crispy_forms',
     'timed.employment',
     'timed.projects',
     'timed.tracking',

--- a/timed/templates/django/forms/widgets/checkbox_option.html
+++ b/timed/templates/django/forms/widgets/checkbox_option.html
@@ -1,2 +1,0 @@
-{% include "django/forms/widgets/input.html" %}
-{% if wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %}>{{ widget.label }}</label>{% endif %}

--- a/timed/urls.py
+++ b/timed/urls.py
@@ -5,7 +5,6 @@ from django.contrib import admin
 from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token
 
 urlpatterns = [
-    url(r'^jet/',                include('jet.urls', 'jet')),
     url(r'^admin/',              admin.site.urls),
     url(r'^api/v1/auth/login',   obtain_jwt_token,  name='login'),
     url(r'^api/v1/auth/refresh', refresh_jwt_token, name='refresh'),


### PR DESCRIPTION
Jet and crispy forms do not add any more functionality but add higher complexity which makes updating of Django more difficult.