### PR TITLE
Improve usability of user admin view

### DIFF
--- a/timed/employment/admin.py
+++ b/timed/employment/admin.py
@@ -19,22 +19,6 @@ class SupervisorInline(admin.TabularInline):
     verbose_name_plural = _('Supervisors')
 
 
-@admin.register(models.User)
-class UserAdmin(UserAdmin):
-    """Timed specific user admin."""
-
-    inlines = [SupervisorInline]
-    exclude = ('supervisors', )
-
-
-@admin.register(models.Location)
-class LocationAdmin(admin.ModelAdmin):
-    """Location admin view."""
-
-    list_display  = ['name']
-    search_fields = ['name']
-
-
 class EmploymentForm(forms.ModelForm):
     """Custom form for the employment admin."""
 
@@ -95,13 +79,39 @@ class EmploymentForm(forms.ModelForm):
         model = models.Employment
 
 
-@admin.register(models.Employment)
-class EmploymentAdmin(admin.ModelAdmin):
-    """Employment admin view."""
+class EmploymentInline(admin.TabularInline):
+    form = EmploymentForm
+    model = models.Employment
+    extra = 0
 
-    form         = EmploymentForm
-    list_display = ['__str__', 'percentage', 'location']
-    list_filter  = ['location', 'user']
+
+class OvertimeCreditInline(admin.TabularInline):
+    model = models.OvertimeCredit
+    extra = 0
+
+
+class AbsenceCreditInline(admin.TabularInline):
+    model = models.AbsenceCredit
+    extra = 0
+
+
+@admin.register(models.User)
+class UserAdmin(UserAdmin):
+    """Timed specific user admin."""
+
+    inlines = [
+        SupervisorInline, EmploymentInline,
+        OvertimeCreditInline, AbsenceCreditInline
+    ]
+    exclude = ('supervisors', )
+
+
+@admin.register(models.Location)
+class LocationAdmin(admin.ModelAdmin):
+    """Location admin view."""
+
+    list_display  = ['name']
+    search_fields = ['name']
 
 
 @admin.register(models.PublicHoliday)
@@ -117,19 +127,3 @@ class AbsenceTypeAdmin(admin.ModelAdmin):
     """Absence type admin view."""
 
     list_display = ['name']
-
-
-@admin.register(models.AbsenceCredit)
-class AbsenceCreditAdmin(admin.ModelAdmin):
-    """Absence credit admin view."""
-
-    list_display = ['absence_type', 'user', 'duration', 'date']
-    list_filter  = ['absence_type', 'user']
-
-
-@admin.register(models.OvertimeCredit)
-class OvertimeCreditAdmin(admin.ModelAdmin):
-    """Overtime credit admin view."""
-
-    list_display = ['user', 'duration', 'date']
-    list_filter  = ['user']


### PR DESCRIPTION
Employments, absences and overtime credits can now be configured
directly inline of the given user.

To avoid merge conflicts this is based on PR #35 so shouldn't be merged before it.