### PR TITLE
JWT needs to be authenticated before django admin session

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -133,8 +133,8 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
         'timed.authentication.JSONWebTokenAuthenticationQueryParam',
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_METADATA_CLASS':
         'rest_framework_json_api.metadata.JSONAPIMetadata',


### PR DESCRIPTION
Otherwise when exporting a report it would take authentication of session which is not desired.