### PR TITLE
Per default end points return archived objects

### DIFF
--- a/timed/employment/filters.py
+++ b/timed/employment/filters.py
@@ -34,3 +34,9 @@ class PublicHolidayFilterSet(FilterSet):
 
         model  = models.PublicHoliday
         fields = ['year', 'location', 'date', 'from_date', 'to_date']
+
+
+class UserFilterSet(FilterSet):
+    class Meta:
+        model  = models.User
+        fields = ['is_active']

--- a/timed/projects/tests/test_customer.py
+++ b/timed/projects/tests/test_customer.py
@@ -30,7 +30,7 @@ class CustomerTests(JSONAPITestCase):
         url = reverse('customer-list')
 
         noauth_res = self.noauth_client.get(url)
-        res        = self.client.get(url)
+        res        = self.client.get(url, data={'archived': False})
 
         assert noauth_res.status_code == HTTP_401_UNAUTHORIZED
         assert res.status_code == HTTP_200_OK

--- a/timed/projects/tests/test_project.py
+++ b/timed/projects/tests/test_project.py
@@ -30,7 +30,7 @@ class ProjectTests(JSONAPITestCase):
         url = reverse('project-list')
 
         noauth_res = self.noauth_client.get(url)
-        res        = self.client.get(url)
+        res        = self.client.get(url, data={'archived': False})
 
         assert noauth_res.status_code == HTTP_401_UNAUTHORIZED
         assert res.status_code == HTTP_200_OK

--- a/timed/projects/tests/test_task.py
+++ b/timed/projects/tests/test_task.py
@@ -29,7 +29,7 @@ class TaskTests(JSONAPITestCase):
         url = reverse('task-list')
 
         noauth_res = self.noauth_client.get(url)
-        res        = self.client.get(url)
+        res        = self.client.get(url, data={'archived': False})
 
         assert noauth_res.status_code == HTTP_401_UNAUTHORIZED
         assert res.status_code == HTTP_200_OK

--- a/timed/projects/views.py
+++ b/timed/projects/views.py
@@ -20,8 +20,6 @@ class CustomerViewSet(ReadOnlyModelViewSet):
         """
         return models.Customer.objects.prefetch_related(
             'projects'
-        ).filter(
-            archived=False
         )
 
 
@@ -40,8 +38,6 @@ class ProjectViewSet(ReadOnlyModelViewSet):
         """
         return models.Project.objects.select_related(
             'customer'
-        ).filter(
-            archived=False
         )
 
 
@@ -60,8 +56,6 @@ class TaskViewSet(ReadOnlyModelViewSet):
         """
         return models.Task.objects.select_related(
             'project'
-        ).filter(
-            archived=False
         )
 
     def filter_queryset(self, queryset):


### PR DESCRIPTION
Filters are added to Customer, Project, Task and User end point
to be able to filter archived and non-archived objects.

Following changes need to be made in Timed-Frontend:
* In tracking and reschedule part only active customer, projects and tasks should be shown
* In project analysis all should be shown