### PR TITLE
Disallow changing of verified reports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'pyexcel-ods3==0.4.0',
         'pyexcel-xlsx==0.4.1',
         'django-environ==0.4.3',
+        'rest_condition==1.0.3',
     ),
     keywords='timetracking',
     url='https://adfinis-sygroup.ch/',


### PR DESCRIPTION
Only admin users may change verified reports as owner doesn't know whether item has already been billed.