### PR TITLE
Change default ordering on ReportViewSet to date

### DIFF
--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -87,7 +87,7 @@ class ReportViewSet(ModelViewSet):
         # all authenticated users may read all reports
         C(IsAuthenticated) & C(IsReadOnly)
     ]
-    ordering = ('id', )
+    ordering = ('date', )
     ordering_fields = (
         'date',
         'duration',


### PR DESCRIPTION
Makes api cleaner as ordering is predictable for humans whereas ids are not.