### PR TITLE
Worktime calculation needs to be calculated across employments

### DIFF
--- a/timed/employment/models.py
+++ b/timed/employment/models.py
@@ -243,12 +243,9 @@ class EmploymentManager(models.Manager):
             end=functions.Coalesce('end_date', models.Value(date.today()))
         )
         return queryset.filter(
-            # using end field as defined as Coalesce above
-            (
-                models.Q(start_date__range=[start, end]) |
-                models.Q(end__range=[start, end])
-            ),
             user=user
+        ).exclude(
+            models.Q(end__lt=start) | models.Q(start_date__gt=end)
         )
 
 

--- a/timed/employment/models.py
+++ b/timed/employment/models.py
@@ -242,13 +242,12 @@ class UserAbsenceType(AbsenceType):
 class EmploymentManager(models.Manager):
     """Custom manager for employments."""
 
-    def for_user(self, user, date=date.today()):
-        """Get the employment on a date for a user.
+    def get_at(self, user, date):
+        """Get employment of user at given date.
 
-        :param User user: The user of the searched employment
-        :param datetime.date date: The date of the searched employment
-        :returns: The employment on the date for the user
-        :rtype: timed.employment.models.Employment
+        :param User user: The user of the searched employments
+        :param datetime.date date: date of employment
+        :returns: Employment
         """
         return self.get(
             (
@@ -256,6 +255,23 @@ class EmploymentManager(models.Manager):
                 models.Q(end_date__isnull=True)
             ),
             start_date__lte=date,
+            user=user
+        )
+
+    def for_user(self, user, start, end):
+        """Get employments in given time frame for current user.
+
+        :param User user: The user of the searched employments
+        :param datetime.date start: start of time frame
+        :param datetime.date end: end of time frame
+        :returns: queryset of employments
+        """
+        return self.filter(
+            (
+                models.Q(end_date__gte=end) |
+                models.Q(end_date__isnull=True)
+            ),
+            start_date__lte=start,
             user=user
         )
 

--- a/timed/employment/serializers.py
+++ b/timed/employment/serializers.py
@@ -42,15 +42,7 @@ class UserSerializer(ModelSerializer):
             ),
             '%Y-%m-%d'
         ).date()
-
-        try:
-            employment = models.Employment.objects.for_user(instance, end)
-        except models.Employment.DoesNotExist:
-            return models.UserAbsenceType.objects.none()
-
-        start = max(
-            employment.start_date, date(date.today().year, 1, 1)
-        )
+        start = date(end.year, 1, 1)
 
         return models.UserAbsenceType.objects.with_user(instance,
                                                         start,
@@ -89,7 +81,7 @@ class UserSerializer(ModelSerializer):
         end = end or date.today()
 
         try:
-            employment = models.Employment.objects.for_user(user, end)
+            employment = models.Employment.objects.get_at(user, end)
         except models.Employment.DoesNotExist:
             # If there is no active employment, set the balance to 0
             return timedelta(), timedelta(), timedelta()

--- a/timed/employment/tests/test_employment.py
+++ b/timed/employment/tests/test_employment.py
@@ -123,13 +123,13 @@ class EmploymentTests(JSONAPITestCase):
         with pytest.raises(ValueError):
             form.save()
 
-    def test_employment_at(self):
+    def test_employment_get_at(self):
         """Should return the right employment on a date."""
         employment = Employment.objects.get(user=self.user,
                                             end_date__isnull=True)
 
         assert (
-            Employment.objects.for_user(self.user, employment.start_date) ==
+            Employment.objects.get_at(self.user, employment.start_date) ==
             employment
         )
 
@@ -141,7 +141,7 @@ class EmploymentTests(JSONAPITestCase):
         employment.save()
 
         with pytest.raises(Employment.DoesNotExist):
-            Employment.objects.for_user(
+            Employment.objects.get_at(
                 self.user,
                 employment.start_date + timedelta(days=21)
             )

--- a/timed/employment/tests/test_employment.py
+++ b/timed/employment/tests/test_employment.py
@@ -264,3 +264,37 @@ def test_worktime_balance_longer(db):
     assert expected == expected_expected
     assert reported == expected_reported
     assert balance == expected_balance
+
+
+def test_employment_for_user(db):
+    user = factories.UserFactory.create()
+    # employment overlapping time frame (early start)
+    factories.EmploymentFactory.create(
+        start_date=date(2017, 1, 1),
+        end_date=date(2017, 2, 28),
+        user=user
+    )
+    # employment overlapping time frame (early end)
+    factories.EmploymentFactory.create(
+        start_date=date(2017, 3, 1),
+        end_date=date(2017, 3, 31),
+        user=user
+    )
+    # employment within time frame
+    factories.EmploymentFactory.create(
+        start_date=date(2017, 4, 1),
+        end_date=date(2017, 4, 30),
+        user=user
+    )
+    # employment without end date
+    factories.EmploymentFactory.create(
+        start_date=date(2017, 5, 1),
+        end_date=None,
+        user=user
+    )
+
+    employments = Employment.objects.for_user(
+        user, date(2017, 2, 1), date(2017, 12, 1)
+    )
+
+    assert employments.count() == 4

--- a/timed/employment/tests/test_employment.py
+++ b/timed/employment/tests/test_employment.py
@@ -1,16 +1,17 @@
 """Tests for the employments endpoint."""
 
-import datetime
+from datetime import date, timedelta
 
 import pytest
 from django.core.urlresolvers import reverse
 from rest_framework.status import (HTTP_200_OK, HTTP_401_UNAUTHORIZED,
                                    HTTP_405_METHOD_NOT_ALLOWED)
 
+from timed.employment import factories
 from timed.employment.admin import EmploymentForm
-from timed.employment.factories import EmploymentFactory
 from timed.employment.models import Employment
 from timed.jsonapi_test_case import JSONAPITestCase
+from timed.tracking.factories import ReportFactory
 
 
 class EmploymentTests(JSONAPITestCase):
@@ -24,14 +25,18 @@ class EmploymentTests(JSONAPITestCase):
         super().setUp()
 
         self.employments = [
-            EmploymentFactory.create(user=self.user,
-                                     start_date=datetime.date(2010, 1, 1),
-                                     end_date=datetime.date(2015, 1, 1)),
-            EmploymentFactory.create(user=self.user,
-                                     start_date=datetime.date(2015, 1, 2))
+            factories.EmploymentFactory.create(
+                user=self.user,
+                start_date=date(2010, 1, 1),
+                end_date=date(2015, 1, 1)
+            ),
+            factories.EmploymentFactory.create(
+                user=self.user,
+                start_date=date(2015, 1, 2)
+            )
         ]
 
-        EmploymentFactory.create_batch(10)
+        factories.EmploymentFactory.create_batch(10)
 
     def test_employment_list(self):
         """Should respond with a list of employments."""
@@ -111,8 +116,8 @@ class EmploymentTests(JSONAPITestCase):
     def test_employment_unique_range(self):
         """Should only be able to have one employment at a time per user."""
         form = EmploymentForm({
-            'start_date': datetime.date(2009, 1, 1),
-            'end_date':   datetime.date(2016, 1, 1)
+            'start_date': date(2009, 1, 1),
+            'end_date':   date(2016, 1, 1)
         }, instance=self.employments[0])
 
         with pytest.raises(ValueError):
@@ -130,7 +135,7 @@ class EmploymentTests(JSONAPITestCase):
 
         employment.end_date = (
             employment.start_date +
-            datetime.timedelta(days=20)
+            timedelta(days=20)
         )
 
         employment.save()
@@ -138,5 +143,124 @@ class EmploymentTests(JSONAPITestCase):
         with pytest.raises(Employment.DoesNotExist):
             Employment.objects.for_user(
                 self.user,
-                employment.start_date + datetime.timedelta(days=21)
+                employment.start_date + timedelta(days=21)
             )
+
+
+def test_worktime_balance_partial(db):
+    """
+    Test partial calculation of worktime balance.
+
+    Partial is defined as a worktime balance of a time frame
+    which is shorter than employment.
+    """
+    employment = factories.EmploymentFactory.create(
+        start_date=date(2010, 1, 1),
+        end_date=None,
+        worktime_per_day=timedelta(hours=8)
+    )
+    user = employment.user
+
+    # Calculate over one week
+    start = date(2017, 3, 19)
+    end   = date(2017, 3, 26)
+
+    # Overtime credit of 10.5 hours
+    factories.OvertimeCreditFactory.create(
+        user=user,
+        date=start,
+        duration=timedelta(hours=10, minutes=30)
+    )
+
+    # One public holiday during workdays
+    factories.PublicHolidayFactory.create(
+        date=start,
+        location=employment.location
+    )
+    # One public holiday on weekend
+    factories.PublicHolidayFactory.create(
+        date=start + timedelta(days=1),
+        location=employment.location
+    )
+    # 5 workdays minus one holiday (32 hours)
+    expected_expected = timedelta(hours=32)
+
+    # reported 2 days each 10 hours
+    for day in range(3, 5):
+        ReportFactory.create(
+            user=user,
+            date=start + timedelta(days=day),
+            duration=timedelta(hours=10)
+        )
+    # 10 hours reported time + 10.5 overtime credit
+    expected_reported = timedelta(hours=30, minutes=30)
+    expected_balance = expected_reported - expected_expected
+
+    reported, expected, balance = employment.calculate_worktime(start, end)
+
+    assert expected == expected_expected
+    assert reported == expected_reported
+    assert balance == expected_balance
+
+
+def test_worktime_balance_longer(db):
+    """Test calculation of worktime when frame is longer than employment."""
+    employment = factories.EmploymentFactory.create(
+        start_date=date(2017, 3, 21),
+        end_date=date(2017, 3, 27),
+        worktime_per_day=timedelta(hours=8)
+    )
+    user = employment.user
+
+    # Calculate over one year
+    start = date(2017, 1, 1)
+    end   = date(2017, 12, 31)
+
+    # Overtime credit of 10.5 hours before employment
+    factories.OvertimeCreditFactory.create(
+        user=user,
+        date=start,
+        duration=timedelta(hours=10, minutes=30)
+    )
+    # Overtime credit of during employment
+    factories.OvertimeCreditFactory.create(
+        user=user,
+        date=employment.start_date,
+        duration=timedelta(hours=10, minutes=30)
+    )
+
+    # One public holiday during employment
+    factories.PublicHolidayFactory.create(
+        date=employment.start_date,
+        location=employment.location
+    )
+    # One public holiday before employment started
+    factories.PublicHolidayFactory.create(
+        date=date(2017, 3, 20),
+        location=employment.location
+    )
+    # 5 workdays minus one holiday (32 hours)
+    expected_expected = timedelta(hours=32)
+
+    # reported 2 days each 10 hours
+    for day in range(3, 5):
+        ReportFactory.create(
+            user=user,
+            date=employment.start_date + timedelta(days=day),
+            duration=timedelta(hours=10)
+        )
+    # reported time not on current employment
+    ReportFactory.create(
+        user=user,
+        date=date(2017, 1, 5),
+        duration=timedelta(hours=10)
+    )
+    # 10 hours reported time + 10.5 overtime credit
+    expected_reported = timedelta(hours=30, minutes=30)
+    expected_balance = expected_reported - expected_expected
+
+    reported, expected, balance = employment.calculate_worktime(start, end)
+
+    assert expected == expected_expected
+    assert reported == expected_reported
+    assert balance == expected_balance

--- a/timed/reports/management/commands/notify_supervisors_shorttime.py
+++ b/timed/reports/management/commands/notify_supervisors_shorttime.py
@@ -6,8 +6,6 @@ from django.core.mail import send_mass_mail
 from django.core.management.base import BaseCommand
 from django.template.loader import render_to_string
 
-from timed.employment.serializers import UserSerializer
-
 
 class Command(BaseCommand):
     """
@@ -28,10 +26,6 @@ class Command(BaseCommand):
     """
 
     help = 'Notify supervisors when supervisees have reported shortime.'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.serializer = UserSerializer()
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -85,7 +79,7 @@ class Command(BaseCommand):
         supervisees_shorttime = {}
         supervisees = get_user_model().objects.all_supervisees()
         for supervisee in supervisees:
-            worktime = self.serializer.get_worktime(supervisee, start, end)
+            worktime = supervisee.calculate_worktime(start, end)
             reported, expected, balance = worktime
             if expected == timedelta(0):
                 continue

--- a/timed/tracking/factories.py
+++ b/timed/tracking/factories.py
@@ -108,7 +108,7 @@ class AbsenceFactory(DjangoModelFactory):
         :return: The computed duration
         :rtype:  datetime.timedelta
         """
-        return Employment.objects.for_user(
+        return Employment.objects.get_at(
             self.user,
             self.date
         ).worktime_per_day

--- a/timed/tracking/models.py
+++ b/timed/tracking/models.py
@@ -187,7 +187,7 @@ class Absence(models.Model):
         difference between the reported time and the worktime per day.
         """
         from timed.employment.models import Employment
-        employment = Employment.objects.for_user(self.user, self.date)
+        employment = Employment.objects.get_at(self.user, self.date)
 
         if self.type.fill_worktime:
             worktime = sum(

--- a/timed/tracking/models.py
+++ b/timed/tracking/models.py
@@ -6,8 +6,6 @@ from django.conf import settings
 from django.db import models
 from django.db.models import F, Sum
 
-from timed.employment.models import Employment
-
 
 class Activity(models.Model):
     """Activity model.
@@ -188,6 +186,7 @@ class Absence(models.Model):
         sickness), in which case the duration of the absence needs to fill the
         difference between the reported time and the worktime per day.
         """
+        from timed.employment.models import Employment
         employment = Employment.objects.for_user(self.user, self.date)
 
         if self.type.fill_worktime:

--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -202,7 +202,7 @@ class AbsenceSerializer(ModelSerializer):
         :returns: The validated data
         :rtype:   dict
         """
-        location = Employment.objects.for_user(
+        location = Employment.objects.get_at(
             data.get('user'),
             data.get('date')
         ).location

--- a/timed/tracking/tests/test_absence.py
+++ b/timed/tracking/tests/test_absence.py
@@ -170,7 +170,7 @@ class AbsenceTests(JSONAPITestCase):
         """Should create an absence which fills the worktime."""
         date       = datetime.date(2017, 5, 10)
         type       = AbsenceTypeFactory.create(fill_worktime=True)
-        employment = Employment.objects.for_user(self.user, date)
+        employment = Employment.objects.get_at(self.user, date)
 
         employment.worktime_per_day = datetime.timedelta(hours=8)
         employment.save()
@@ -244,7 +244,7 @@ class AbsenceTests(JSONAPITestCase):
         type = AbsenceTypeFactory.create()
 
         PublicHolidayFactory.create(
-            location=Employment.objects.for_user(self.user, date).location,
+            location=Employment.objects.get_at(self.user, date).location,
             date=date
         )
 


### PR DESCRIPTION
Only current employment was taken for worktime balance calculation which led to issues in calculation when employment changed within a year. This has been solved by calculation worktime for each employment and summarizing them.