### PR TITLE
Total hours needs to be zero when there are no reports

### DIFF
--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -1,4 +1,5 @@
 """Serializers for the tracking app."""
+from datetime import timedelta
 
 from django.contrib.auth import get_user_model
 from django.db.models import Sum
@@ -173,7 +174,9 @@ class ReportSerializer(ModelSerializer):
             view = self.context['view']
             queryset = view.filter_queryset(view.get_queryset())
             data = queryset.aggregate(total_hours=Sum('duration'))
-            data['total_hours'] = duration_string(data['total_hours'])
+            data['total_hours'] = duration_string(
+                data['total_hours'] or timedelta(0)
+            )
             return data
         return {}
 

--- a/timed/tracking/tests/test_report.py
+++ b/timed/tracking/tests/test_report.py
@@ -516,3 +516,12 @@ class TestReportHypo(TestCase):
         # bookdict is a dict of tuples(name, content)
         sheet = book.bookdict.popitem()[1]
         assert len(sheet) == len(reports) + 1
+
+
+def test_report_list_no_result(admin_client):
+    url = reverse('report-list')
+    res = admin_client.get(url)
+
+    assert res.status_code == HTTP_200_OK
+    json = res.json()
+    assert json['meta']['total-hours'] == '00:00:00'


### PR DESCRIPTION
This for example avoids a 500 error when trying to retrieve reports of a single day where nothing has been booked yet.