### PR TITLE
No coverage on fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,4 @@ test: ## Test the project
 	./manage.py migrate --noinput
 	./manage.py makemigrations --check --dry-run --noinput
 	@flake8
-	@pytest --cov --create-db
+	@pytest --no-cov-on-fail --cov --create-db


### PR DESCRIPTION
When tests fails coverage is inaccurate so disabling on failure it to receive quicker results on.