### PR TITLE
Do not show archived tasks in frequently used tasks

### DIFF
--- a/timed/projects/filters.py
+++ b/timed/projects/filters.py
@@ -63,7 +63,12 @@ class MyMostFrequentTaskFilter(Filter):
         user = self.parent.request.user
         from_date = date.today() - timedelta(days=60)
 
-        qs = qs.filter(reports__user=user, reports__date__gt=from_date)
+        qs = qs.filter(
+            reports__user=user,
+            reports__date__gt=from_date,
+            archived=False,
+            project__archived=False
+        )
         qs = qs.annotate(frequency=Count('reports')).order_by('-frequency')
         # limit number of results to given value
         qs = qs[:int(value)]

--- a/timed/projects/tests/test_task.py
+++ b/timed/projects/tests/test_task.py
@@ -59,6 +59,18 @@ class TaskTests(JSONAPITestCase):
         ReportFactory.create_batch(
             4, date=old_report_date, user=self.user, task=self.tasks[2]
         )
+        # tasks[3] should not appear in result, as project is archived
+        self.tasks[3].project.archived = True
+        self.tasks[3].project.save()
+        ReportFactory.create_batch(
+            4, date=report_date, user=self.user, task=self.tasks[3]
+        )
+        # tasks[4] should not appear in result, as task is archived
+        self.tasks[4].archived = True
+        self.tasks[4].save()
+        ReportFactory.create_batch(
+            4, date=report_date, user=self.user, task=self.tasks[4]
+        )
 
         url = reverse('task-list')
 


### PR DESCRIPTION
User is not allowed to book onto archived tasks resp. projects so they should not appear in frequently used list of tasks.