### PR TITLE
Move worktime calculation into its own end point

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -17,4 +17,4 @@ pytest-mock==1.6.2
 # once newer version than 3.1.2 has been released
 # pytest-django can be imported through pypi again
 git+https://github.com/pytest-dev/pytest-django@21492af
-pytest-freezegun==0.1.0
+pytest-freezegun==0.2.0

--- a/timed/employment/filters.py
+++ b/timed/employment/filters.py
@@ -65,3 +65,11 @@ class AbsenceCreditFilterSet(FilterSet):
         fields = [
             'year', 'user', 'date', 'from_date', 'to_date', 'absence_type'
         ]
+
+
+class WorktimeBalanceFilterSet(FilterSet):
+    user = NumberFilter(name='id')
+
+    class Meta:
+        model  = models.User
+        fields = ['user']

--- a/timed/employment/models.py
+++ b/timed/employment/models.py
@@ -358,7 +358,7 @@ class Employment(models.Model):
                 user=self.user_id,
                 date__gte=start,
                 date__lte=end,
-            )
+            ).select_related('type')
         ], timedelta())
 
         reported = reported_worktime + absences + overtime_credit

--- a/timed/employment/tests/test_user.py
+++ b/timed/employment/tests/test_user.py
@@ -2,17 +2,14 @@
 
 from datetime import date, timedelta
 
-from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
-from django.utils.duration import duration_string
 from rest_framework import status
 from rest_framework.status import (HTTP_200_OK, HTTP_401_UNAUTHORIZED,
                                    HTTP_405_METHOD_NOT_ALLOWED)
 
 from timed.employment.factories import (AbsenceCreditFactory,
                                         AbsenceTypeFactory, EmploymentFactory,
-                                        OvertimeCreditFactory,
-                                        PublicHolidayFactory, UserFactory)
+                                        UserFactory)
 from timed.jsonapi_test_case import JSONAPITestCase
 from timed.tracking.factories import AbsenceFactory, ReportFactory
 
@@ -138,26 +135,6 @@ class UserTests(JSONAPITestCase):
         assert noauth_res.status_code == HTTP_401_UNAUTHORIZED
         assert res.status_code == HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_user_without_employment(self):
-        user = get_user_model().objects.create_user(username='test',
-                                                    password='1234qwer')
-        self.client.login('test', '1234qwer')
-
-        url = reverse('user-detail', args=[
-            user.id
-        ])
-
-        res = self.client.get(url)
-
-        assert res.status_code == HTTP_200_OK
-
-        result = self.result(res)
-
-        assert int(result['data']['id']) == user.id
-        assert result['data']['attributes']['worktime-balance'] == (
-            '00:00:00'
-        )
-
     def test_user_absence_types(self):
         absence_type = AbsenceTypeFactory.create()
 
@@ -257,100 +234,6 @@ class UserTests(JSONAPITestCase):
         assert inc[0]['attributes']['balance'] is None
         assert inc[0]['attributes']['used-days'] is None
         assert inc[0]['attributes']['used-duration'] == '06:00:00'
-
-
-def test_user_worktime_balance(auth_client):
-    """Should calculate correct worktime balances."""
-    # Calculate over one week
-    start_date = date(2017, 3, 19)
-    end_date   = date(2017, 3, 26)
-
-    user       = auth_client.user
-    employment = EmploymentFactory.create(
-        user=user,
-        start_date=start_date,
-        worktime_per_day=timedelta(hours=8, minutes=30),
-        end_date=date(2017, 3, 23)
-    )
-    employment_short = EmploymentFactory.create(
-        user=user,
-        start_date=date(2017, 3, 24),
-        worktime_per_day=timedelta(hours=8),
-        end_date=None
-    )
-
-    # Overtime credit of 10 hours
-    OvertimeCreditFactory.create(
-        user=user,
-        date=start_date,
-        duration=timedelta(hours=10, minutes=30)
-    )
-
-    # One public holiday during workdays
-    PublicHolidayFactory.create(
-        date=start_date,
-        location=employment.location
-    )
-    # One public holiday on weekend
-    PublicHolidayFactory.create(
-        date=start_date + timedelta(days=1),
-        location=employment.location
-    )
-
-    url = reverse('user-detail', args=[
-        user.id
-    ])
-
-    res = auth_client.get('{0}?until={1}'.format(
-        url,
-        end_date.strftime('%Y-%m-%d')
-    ))
-
-    result = res.json()
-
-    # Calculated result:
-    # 4 workdays 8.5 hours, 1 workday 8 hours, minus one holiday 8.5
-    # minutes 10.5 hours overtime credit
-    expected_worktime = (
-        1 * employment_short.worktime_per_day +
-        3 * employment.worktime_per_day -
-        timedelta(hours=10, minutes=30)
-    )
-
-    assert (
-        result['data']['attributes']['worktime-balance'] ==
-        duration_string(timedelta() - expected_worktime)
-    )
-
-    # 2x 10 hour reported worktime
-    ReportFactory.create(
-        user=user,
-        date=start_date + timedelta(days=3),
-        duration=timedelta(hours=10)
-    )
-
-    ReportFactory.create(
-        user=user,
-        date=start_date + timedelta(days=4),
-        duration=timedelta(hours=10)
-    )
-
-    AbsenceFactory.create(
-        user=user,
-        date=start_date + timedelta(days=5)
-    )
-
-    res2 = auth_client.get('{0}?until={1}'.format(
-        url,
-        end_date.strftime('%Y-%m-%d')
-    ))
-
-    result2 = res2.json()
-
-    assert (
-        result2['data']['attributes']['worktime-balance'] ==
-        duration_string(timedelta(hours=28) - expected_worktime)
-    )
 
 
 def test_user_supervisor_filter(auth_client):

--- a/timed/employment/tests/test_worktime_balance.py
+++ b/timed/employment/tests/test_worktime_balance.py
@@ -1,0 +1,188 @@
+from datetime import date, timedelta
+
+from django.core.urlresolvers import reverse
+from django.utils.duration import duration_string
+from rest_framework import status
+
+from timed.employment.factories import (EmploymentFactory,
+                                        OvertimeCreditFactory,
+                                        PublicHolidayFactory, UserFactory)
+from timed.tracking.factories import AbsenceFactory, ReportFactory
+
+
+def test_worktime_balance_create(auth_client):
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.post(url)
+    assert result.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+
+def test_worktime_balance_no_employment(auth_client,
+                                        django_assert_num_queries):
+    url = reverse('worktime-balance-list')
+
+    with django_assert_num_queries(4):
+        result = auth_client.get(url, data={
+            'user': auth_client.user.id,
+            'date': '2017-01-01',
+        })
+
+    assert result.status_code == status.HTTP_200_OK
+
+    json = result.json()
+    assert len(json['data']) == 1
+    data = json['data'][0]
+    assert data['id'] == '{0}_2017-01-01'.format(auth_client.user.id)
+    assert data['attributes']['balance'] == '00:00:00'
+
+
+def test_worktime_balance_with_employments(auth_client,
+                                           django_assert_num_queries):
+    # Calculate over one week
+    start_date = date(2017, 3, 19)
+    end_date   = date(2017, 3, 26)
+
+    employment = EmploymentFactory.create(
+        user=auth_client.user,
+        start_date=start_date,
+        worktime_per_day=timedelta(hours=8, minutes=30),
+        end_date=date(2017, 3, 23)
+    )
+    EmploymentFactory.create(
+        user=auth_client.user,
+        start_date=date(2017, 3, 24),
+        worktime_per_day=timedelta(hours=8),
+        end_date=None
+    )
+
+    # Overtime credit of 10 hours
+    OvertimeCreditFactory.create(
+        user=auth_client.user,
+        date=start_date,
+        duration=timedelta(hours=10, minutes=30)
+    )
+
+    # One public holiday during workdays
+    PublicHolidayFactory.create(
+        date=start_date,
+        location=employment.location
+    )
+    # One public holiday on weekend
+    PublicHolidayFactory.create(
+        date=start_date + timedelta(days=1),
+        location=employment.location
+    )
+
+    # 2x 10 hour reported worktime
+    ReportFactory.create(
+        user=auth_client.user,
+        date=start_date + timedelta(days=3),
+        duration=timedelta(hours=10)
+    )
+
+    ReportFactory.create(
+        user=auth_client.user,
+        date=start_date + timedelta(days=4),
+        duration=timedelta(hours=10)
+    )
+
+    # one absence
+    AbsenceFactory.create(
+        user=auth_client.user,
+        date=start_date + timedelta(days=5)
+    )
+
+    url = reverse('worktime-balance-detail', args=[
+        '{0}_{1}'.format(auth_client.user.id, end_date.strftime('%Y-%m-%d'))
+    ])
+
+    with django_assert_num_queries(12):
+        result = auth_client.get(url)
+    assert result.status_code == status.HTTP_200_OK
+
+    # 4 workdays 8.5 hours, 1 workday 8 hours, minus one holiday 8.5
+    # minutes 10.5 hours overtime credit
+    expected_worktime = timedelta(hours=23)
+
+    # 2 x 10 reports hours + 1 absence of 8 hours
+    expected_reported = timedelta(hours=28)
+
+    json = result.json()
+    assert json['data']['attributes']['balance'] == (
+        duration_string(expected_reported - expected_worktime)
+    )
+
+
+def test_worktime_balance_invalid_pk(auth_client):
+    url = reverse('worktime-balance-detail', args=['invalid'])
+
+    result = auth_client.get(url)
+    assert result.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_worktime_balance_no_date(auth_client):
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.get(url)
+    assert result.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_worktime_balance_invalid_date(auth_client):
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.get(url, data={'date': 'invalid'})
+    assert result.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_user_worktime_list_superuser(auth_client):
+    auth_client.user.is_superuser = True
+    auth_client.user.save()
+    supervisee = UserFactory.create()
+    UserFactory.create()
+    auth_client.user.supervisees.add(supervisee)
+
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.get(url, data={
+        'date': '2017-01-01',
+    })
+
+    assert result.status_code == status.HTTP_200_OK
+
+    json = result.json()
+    assert len(json['data']) == 3
+
+
+def test_worktime_balance_list_supervisor(auth_client):
+    supervisee = UserFactory.create()
+    UserFactory.create()
+    auth_client.user.supervisees.add(supervisee)
+
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.get(url, data={
+        'date': '2017-01-01',
+    })
+
+    assert result.status_code == status.HTTP_200_OK
+
+    json = result.json()
+    assert len(json['data']) == 2
+
+
+def test_worktime_balance_list_filter_user(auth_client):
+    supervisee = UserFactory.create()
+    UserFactory.create()
+    auth_client.user.supervisees.add(supervisee)
+
+    url = reverse('worktime-balance-list')
+
+    result = auth_client.get(url, data={
+        'date': '2017-01-01',
+        'user': supervisee.id
+    })
+
+    assert result.status_code == status.HTTP_200_OK
+
+    json = result.json()
+    assert len(json['data']) == 1

--- a/timed/employment/urls.py
+++ b/timed/employment/urls.py
@@ -14,5 +14,10 @@ r.register(r'public-holidays',  views.PublicHolidayViewSet,  'public-holiday')
 r.register(r'absence-types',    views.AbsenceTypeViewSet,    'absence-type')
 r.register(r'overtime-credits', views.OvertimeCreditViewSet, 'overtime-credit')
 r.register(r'absence-credits',  views.AbsenceCreditViewSet,  'absence-credit')
+r.register(
+    r'worktime-balances',
+    views.WorktimeBalanceViewSet,
+    'worktime-balance'
+)
 
 urlpatterns = r.urls

--- a/timed/mixins.py
+++ b/timed/mixins.py
@@ -1,0 +1,72 @@
+from rest_framework_json_api.relations import ResourceRelatedField
+
+
+class AggregateQuerysetMixin(object):
+    """
+    Add support for aggregate queryset in view.
+
+    Wrap queryst dicts into aggregate object to support renderer
+    which expect attributes.
+    It additional prefetches related instances represented as id in
+    aggregate.
+
+    In aggregates only an id of a related field is part of the object.
+    Instead of loading each single object row by row this mixin
+    prefetches all resources related field in injects
+    it before serialization starts.
+
+    Mixin expects the id to be the same key as the resource related
+    field defined in the serializer.
+    """
+
+    class AggregateObject(dict):
+        """
+        Wrap dict into an object.
+
+        All values will be accesible through attributes. Note that
+        keys must be valid python names for this to work.
+        """
+
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+            super().__init__(**kwargs)
+
+    def get_serializer(self, data, *args, **kwargs):
+        many = kwargs.get('many')
+        if not many:
+            data = [data]
+
+        # prefetch data for all related fields
+        prefetch_per_field = {}
+        serializer_class = self.get_serializer_class()
+        for key, value in serializer_class._declared_fields.items():
+            if isinstance(value, ResourceRelatedField):
+                source = value.source or key
+                if many:
+                    obj_ids = data.values_list(source, flat=True)
+                else:
+                    obj_ids = [data[0][source]]
+                objects = {
+                    obj.id: obj
+                    for obj in value.model.objects.filter(
+                        id__in=obj_ids
+                    ).select_related()
+                }
+                prefetch_per_field[source] = objects
+
+        # enhance entry dicts with model instances
+        data = [
+            self.AggregateObject(**{
+                **entry,
+                **{
+                    field: objects[entry[field]]
+                    for field, objects in prefetch_per_field.items()
+                }
+            })
+            for entry in data
+        ]
+
+        if not many:
+            data = data[0]
+
+        return super().get_serializer(data, *args, **kwargs)

--- a/timed/mixins.py
+++ b/timed/mixins.py
@@ -7,13 +7,12 @@ class AggregateQuerysetMixin(object):
 
     Wrap queryst dicts into aggregate object to support renderer
     which expect attributes.
-    It additional prefetches related instances represented as id in
+    It additionaly prefetches related instances represented as id in
     aggregate.
 
     In aggregates only an id of a related field is part of the object.
-    Instead of loading each single object row by row this mixin
-    prefetches all resources related field in injects
-    it before serialization starts.
+    Instead of loading each single object row by row this mixin prefetches
+    all resource related fields and injects it before serialization starts.
 
     Mixin expects the id to be the same key as the resource related
     field defined in the serializer.

--- a/timed/redmine/tests/test_redmine_report.py
+++ b/timed/redmine/tests/test_redmine_report.py
@@ -1,4 +1,3 @@
-import pytest
 from django.core.management import call_command
 from redminelib.exceptions import ResourceNotFoundError
 
@@ -7,7 +6,6 @@ from timed.redmine.models import RedmineProject
 from timed.tracking.factories import ReportFactory
 
 
-@pytest.mark.freeze_time
 def test_redmine_report(db, freezer, mocker):
     """
     Test redmine report.
@@ -47,7 +45,6 @@ def test_redmine_report(db, freezer, mocker):
     issue.save.assert_called_once_with()
 
 
-@pytest.mark.freeze_time
 def test_redmine_report_no_estimated_time(db, freezer, mocker):
     redmine_instance = mocker.MagicMock()
     issue = mocker.MagicMock()
@@ -68,7 +65,6 @@ def test_redmine_report_no_estimated_time(db, freezer, mocker):
     issue.save.assert_called_once_with()
 
 
-@pytest.mark.freeze_time
 def test_redmine_report_invalid_issue(db, freezer, mocker, capsys):
     """Test case when issue is not available."""
     redmine_instance = mocker.MagicMock()

--- a/timed/reports/tests/test_notify_changed_employments.py
+++ b/timed/reports/tests/test_notify_changed_employments.py
@@ -1,12 +1,10 @@
 from datetime import date
 
-import pytest
 from django.core.management import call_command
 
 from timed.employment.factories import EmploymentFactory
 
 
-@pytest.mark.freeze_time
 def test_notify_changed_employments(db, mailoutbox, freezer):
     email = 'test@example.net'
 

--- a/timed/reports/views.py
+++ b/timed/reports/views.py
@@ -10,83 +10,12 @@ from django.db.models.functions import Concat, ExtractMonth, ExtractYear
 from django.http import HttpResponse, HttpResponseBadRequest
 from ezodf import Cell, opendoc
 from rest_framework.viewsets import GenericViewSet, ReadOnlyModelViewSet
-from rest_framework_json_api.relations import ResourceRelatedField
 
+from timed.mixins import AggregateQuerysetMixin
 from timed.reports import serializers
 from timed.tracking.filters import ReportFilterSet
 from timed.tracking.models import Report
 from timed.tracking.views import ReportViewSet
-
-
-class AggregateQuerysetMixin(object):
-    """
-    Add support for aggregate queryset in view.
-
-    Wrap queryst dicts into aggregate object to support renderer
-    which expect attributes.
-    It additional prefetches related instances represented as id in
-    aggregate.
-
-    In aggregates only an id of a related field is part of the object.
-    Instead of loading each single object row by row this mixin
-    prefetches all resources related field in injects
-    it before serialization starts.
-
-    Mixin expects the id to be the same key as the resource related
-    field defined in the serializer.
-    """
-
-    class AggregateObject(dict):
-        """
-        Wrap dict into an object.
-
-        All values will be accesible through attributes. Note that
-        keys must be valid python names for this to work.
-        """
-
-        def __init__(self, **kwargs):
-            self.__dict__.update(kwargs)
-            super().__init__(**kwargs)
-
-    def get_serializer(self, data, *args, **kwargs):
-        many = kwargs.get('many')
-        if not many:
-            data = [data]
-
-        # prefetch data for all related fields
-        prefetch_per_field = {}
-        serializer_class = self.get_serializer_class()
-        for key, value in serializer_class._declared_fields.items():
-            if isinstance(value, ResourceRelatedField):
-                source = value.source or key
-                if many:
-                    obj_ids = data.values_list(source, flat=True)
-                else:
-                    obj_ids = [data[0][source]]
-                objects = {
-                    obj.id: obj
-                    for obj in value.model.objects.filter(
-                        id__in=obj_ids
-                    ).select_related()
-                }
-                prefetch_per_field[source] = objects
-
-        # enhance entry dicts with model instances
-        data = [
-            self.AggregateObject(**{
-                **entry,
-                **{
-                    field: objects[entry[field]]
-                    for field, objects in prefetch_per_field.items()
-                }
-            })
-            for entry in data
-        ]
-
-        if not many:
-            data = data[0]
-
-        return super().get_serializer(data, *args, **kwargs)
 
 
 class YearStatisticViewSet(AggregateQuerysetMixin, ReadOnlyModelViewSet):

--- a/timed/tracking/models.py
+++ b/timed/tracking/models.py
@@ -174,7 +174,7 @@ class Absence(models.Model):
         if not self.type.fill_worktime:
             return employment.worktime_per_day
 
-        reports = Report.objects.filter(date=self.date, user=self.user)
+        reports = Report.objects.filter(date=self.date, user=self.user_id)
         data = reports.aggregate(reported_time=models.Sum('duration'))
         reported_time = data['reported_time'] or timedelta()
         if reported_time >= employment.worktime_per_day:


### PR DESCRIPTION
Give client the ability to calculate worktime on a given date. This PR includes some minor performance improvements in the calculation as well.

User end point won't include a worktime balance anymore. This means this change is not backwards compatible and should not be merged before Frontend has not been updated.