### PR TITLE
Add last reported date filter to worktime balance

### DIFF
--- a/timed/employment/filters.py
+++ b/timed/employment/filters.py
@@ -90,6 +90,9 @@ class AbsenceCreditFilterSet(FilterSet):
 
 class WorktimeBalanceFilterSet(FilterSet):
     user = NumberFilter(name='id')
+    # additional filters analyzed in WorktimeBalanceView
+    # date = DateFilter()
+    # last_reported_date = NumberFilter()
 
     class Meta:
         model  = models.User


### PR DESCRIPTION
Only returns worktime balances of every user at the date when either a report or a absence has been reported.