### PR TITLE
Prefetch verified_by instead of select

### DIFF
--- a/timed/reports/views.py
+++ b/timed/reports/views.py
@@ -139,7 +139,14 @@ class WorkReportViewSet(GenericViewSet):
 
     def get_queryset(self):
         return Report.objects.select_related(
-            'user', 'verified_by'
+            'user', 'task', 'task__project', 'task__project__customer'
+        ).prefetch_related(
+            # need to prefetch verified_by as select_related joins nullable
+            # foreign key verified_by with INNER JOIN instead of LEFT JOIN
+            # which leads to an empty result.
+            # This only happens as user and verified_by points to same table
+            # and user is not nullable
+            'verified_by'
         )
 
     def _parse_query_params(self, queryset, request):

--- a/timed/tracking/filters.py
+++ b/timed/tracking/filters.py
@@ -95,9 +95,10 @@ class ReportFilterSet(FilterSet):
     customer     = NumberFilter(name='task__project__customer')
     review       = NumberFilter(name='review')
     not_billable = NumberFilter(name='not_billable')
-    not_verified = NumberFilter(name='verified_by', lookup_expr='isnull')
+    not_verified = NumberFilter(name='verified_by_id', lookup_expr='isnull')
     reviewer     = NumberFilter(name='task__project__reviewers')
     billing_type = NumberFilter(name='task__project__billing_type')
+    user         = NumberFilter(name='user_id')
     cost_center = NumberFilter(name='cost_center', method='filter_cost_center')
 
     def filter_cost_center(self, queryset, name, value):


### PR DESCRIPTION
`select_related` of Django Queryset joins nullable `verified_by` foreign key with `INNER JOIN` instead of `LEFT JOIN` which causes an empty result when `verified_by` is `NULL`.