### PR TITLE
Reuse db when running pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=timed.settings
+addopts = --reuse-db


### PR DESCRIPTION
`make test` already forces creation of database but this changes increases
performance when running tests on local machine.