### PR TITLE
Allow reviewer, supervisor and superuser to change reports

### DIFF
--- a/timed/permissions.py
+++ b/timed/permissions.py
@@ -1,5 +1,5 @@
 from rest_framework.permissions import (SAFE_METHODS, BasePermission,
-                                        IsAdminUser, IsAuthenticated)
+                                        IsAuthenticated)
 
 
 class IsUnverified(BasePermission):
@@ -53,7 +53,7 @@ class IsAuthenticated(IsAuthenticated):
     """
     Support mixing permission IsAuthenticated with object permission.
 
-    This is needed to use IsAdminUser with rest condition and or
+    This is needed to use IsAuthenticated with rest condition and or
     operator.
     """
 
@@ -75,16 +75,12 @@ class IsSupervisor(IsAuthenticated):
         return request.user.supervisees.filter(id=obj.user_id).exists()
 
 
-class IsAdminUser(IsAdminUser):
-    """
-    Support mixing permission IsAdminUser with object permission.
-
-    This is needed to use IsAdminUser with rest condition and or
-    operator.
-    """
+class IsReviewer(IsAuthenticated):
+    """Allows access to object only to reviewers."""
 
     def has_object_permission(self, request, view, obj):
-        return self.has_permission(request, view)
+        user = request.user
+        return obj.task.project.reviewers.filter(id=user.id).exists()
 
 
 class IsSuperUser(BasePermission):

--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -8,8 +8,9 @@ from rest_framework.decorators import list_route
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from timed.permissions import (IsAdminUser, IsAuthenticated, IsDeleteOnly,
-                               IsOwner, IsReadOnly, IsSuperUser, IsUnverified)
+from timed.permissions import (IsAuthenticated, IsDeleteOnly, IsOwner,
+                               IsReadOnly, IsReviewer, IsSuperUser,
+                               IsSupervisor, IsUnverified)
 from timed.serializers import AggregateObject
 from timed.tracking import filters, models, serializers
 
@@ -82,8 +83,8 @@ class ReportViewSet(ModelViewSet):
     serializer_class = serializers.ReportSerializer
     filter_class     = filters.ReportFilterSet
     permission_classes = [
-        # admin user can change all but not delete
-        C(IsAuthenticated) & C(IsAdminUser) & ~C(IsDeleteOnly) |
+        # reviewer, supervisor or superuser may change but not delete reports
+        (C(IsSuperUser) | C(IsReviewer) | C(IsSupervisor)) & ~C(IsDeleteOnly) |
         # owner may only change its own unverified reports
         C(IsAuthenticated) & C(IsOwner) & C(IsUnverified) |
         # all authenticated users may read all reports


### PR DESCRIPTION
This removes the dependency on the is_staff flag. Instead permissions are given by role of user in terms of given project resp. user.

Whereas supervisor may change report it may not verify it as this is the responsibility of the reviewer. Superuser on the other hand may verify all reports.