### PR TITLE
Pin rest framework to 3.6 series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django>=1.11,<1.12 # pyup: >=1.11,<1.12
 django-auth-ldap==1.2.16
 django-filter==1.1.0
 django-multiselectfield==0.1.8
-djangorestframework>=3.6,<3.7
+djangorestframework==3.6.4 # pyup: >=3.6,<3.7
 djangorestframework-jwt==1.11.0
 psycopg2>=2.7,<2.8
 pytz==2017.3


### PR DESCRIPTION
django-json-api is currently only tested with series 3.6 so need to pin it for safety reasons.