### PR TITLE
Remove obsolete authentication through token query param

### DIFF
--- a/timed/authentication.py
+++ b/timed/authentication.py
@@ -1,8 +1,0 @@
-from rest_framework_jwt.authentication import BaseJSONWebTokenAuthentication
-
-
-class JSONWebTokenAuthenticationQueryParam(BaseJSONWebTokenAuthentication):
-    """Allows json web token to be passed on as GET parameter."""
-
-    def get_jwt_value(self, request):
-        return request.query_params.get('jwt')

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -164,7 +164,6 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
-        'timed.authentication.JSONWebTokenAuthenticationQueryParam',
         'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_METADATA_CLASS':


### PR DESCRIPTION
Frontend doesn't require this anymore for downloads. As it is a security concern that token end up in log files it is better to remove it as not needed anymore.