### PR TITLE
Move from DefaultRouter to SimpleRouter

### DIFF
--- a/timed/employment/urls.py
+++ b/timed/employment/urls.py
@@ -1,11 +1,11 @@
 """URL to view mapping for the employment app."""
 
 from django.conf import settings
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from timed.employment import views
 
-r = DefaultRouter(trailing_slash=settings.APPEND_SLASH)
+r = SimpleRouter(trailing_slash=settings.APPEND_SLASH)
 
 r.register(r'users',            views.UserViewSet,           'user')
 r.register(r'employments',      views.EmploymentViewSet,     'employment')

--- a/timed/projects/urls.py
+++ b/timed/projects/urls.py
@@ -1,11 +1,11 @@
 """URL to view mapping for the projects app."""
 
 from django.conf import settings
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from timed.projects import views
 
-r = DefaultRouter(trailing_slash=settings.APPEND_SLASH)
+r = SimpleRouter(trailing_slash=settings.APPEND_SLASH)
 
 r.register(r'projects',  views.ProjectViewSet,  'project')
 r.register(r'customers', views.CustomerViewSet, 'customer')

--- a/timed/reports/urls.py
+++ b/timed/reports/urls.py
@@ -1,9 +1,9 @@
 from django.conf import settings
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from . import views
 
-r = DefaultRouter(trailing_slash=settings.APPEND_SLASH)
+r = SimpleRouter(trailing_slash=settings.APPEND_SLASH)
 
 r.register(r'work-reports',     views.WorkReportViewSet,     'work-report')
 r.register(r'year-statistics',  views.YearStatisticViewSet,  'year-statistic')

--- a/timed/tracking/urls.py
+++ b/timed/tracking/urls.py
@@ -1,11 +1,11 @@
 """URL to view mapping for the tracking app."""
 
 from django.conf import settings
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from timed.tracking import views
 
-r = DefaultRouter(trailing_slash=settings.APPEND_SLASH)
+r = SimpleRouter(trailing_slash=settings.APPEND_SLASH)
 
 r.register(r'activities',      views.ActivityViewSet,      'activity')
 r.register(r'activity-blocks', views.ActivityBlockViewSet, 'activity-block')


### PR DESCRIPTION
DefaultRouter has a feature to enable root view. This only works though if a single DefaultRouter is used. This is not desired in our case so root view was not complete.

Instead of having a invalid root view it is better to remove it - hence moving to SimpleRouter.