### PR TITLE
Update to newest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,12 @@
-python-dateutil>=2.6,<2.7
-django>=1.11,<1.12 # pyup: >=1.11,<1.12
+python-dateutil==2.6.1
+django==1.11.9 # pyup: >=1.11,<1.12
 django-auth-ldap==1.3.0
 django-filter==1.1.0
 django-multiselectfield==0.1.8
-djangorestframework==3.6.4 # pyup: >=3.6,<3.7
+djangorestframework==3.7.7
 djangorestframework-jwt==1.11.0
-psycopg2>=2.7,<2.8
+djangorestframework-jsonapi==2.4.0
+psycopg2==2.7.3.2
 pytz==2017.3
 pyexcel-webio==0.1.4
 pyexcel-io==0.5.6
@@ -17,7 +18,3 @@ django-environ==0.4.4
 rest_condition==1.0.3
 django-money==0.12.3
 python-redmine==2.0.2
-# TODO: when following PR are released, change back to official release
-# https://github.com/django-json-api/django-rest-framework-json-api/pull/376
-# https://github.com/django-json-api/django-rest-framework-json-api/pull/374
-git+https://github.com/adfinis-forks/django-rest-framework-json-api.git@timed_master


### PR DESCRIPTION
As jsonapi is now also compatible with DRF 3.7 removed fixed dependencies.