### PR TITLE
Update to rest framework 3.8.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 
 # local .env file
 .env
+
+# pytest
+.pytest_cache

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django==1.11.13 # pyup: >=1.11,<1.12
 django-auth-ldap==1.6.1
 django-filter==1.1.0
 django-multiselectfield==0.1.8
-djangorestframework==3.7.7
+djangorestframework==3.8.2
 djangorestframework-jwt==1.11.0
 djangorestframework-jsonapi==2.4.0
 psycopg2==2.7.4

--- a/timed/employment/relations.py
+++ b/timed/employment/relations.py
@@ -1,0 +1,15 @@
+from django.contrib.auth import get_user_model
+from rest_framework_json_api.relations import ResourceRelatedField
+from rest_framework_json_api.serializers import CurrentUserDefault
+
+
+class CurrentUserResourceRelatedField(ResourceRelatedField):
+    """User resource related field restricting user to current user."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs['default'] = CurrentUserDefault()
+        super().__init__(*args, **kwargs)
+
+    def get_queryset(self):
+        request = self.context['request']
+        return get_user_model().objects.filter(pk=request.user.pk)

--- a/timed/employment/views.py
+++ b/timed/employment/views.py
@@ -7,7 +7,7 @@ from django.db.models.functions import Concat
 from django.utils.translation import ugettext_lazy as _
 from rest_condition import C
 from rest_framework import exceptions, status
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
 
@@ -48,7 +48,7 @@ class UserViewSet(ModelViewSet):
             'employments', 'supervisees', 'supervisors'
         )
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def transfer(self, request, pk=None):
         """
         Transfer worktime and absence balance to new year.

--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -7,7 +7,7 @@ from django.http import HttpResponseBadRequest
 from django.utils.translation import ugettext_lazy as _
 from rest_condition import C
 from rest_framework import exceptions, status
-from rest_framework.decorators import list_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
@@ -138,7 +138,8 @@ class ReportViewSet(ModelViewSet):
 
         return name
 
-    @list_route(
+    @action(
+        detail=False,
         methods=['get'],
         serializer_class=serializers.ReportIntersectionSerializer,
     )
@@ -170,7 +171,8 @@ class ReportViewSet(ModelViewSet):
         serializer = self.get_serializer(data)
         return Response(data=serializer.data)
 
-    @list_route(
+    @action(
+        detail=False,
         methods=['post'],
         # all users are allowed to bulk update but only on filtered result
         permission_classes=[IsAuthenticated],
@@ -219,7 +221,7 @@ class ReportViewSet(ModelViewSet):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
-    @list_route(methods=['get'])
+    @action(methods=['get'], detail=False)
     def export(self, request):
         """Export filtered reports to given file format."""
         queryset = self.get_queryset().select_related(


### PR DESCRIPTION
Fixes #268

Beside some deprecation warnings main issue to fix was that read_only and default may not be used together anymore. Replaced with `CurrentUserResourceRelatedField.`