### PR TITLE
Add activity permission

### DIFF
--- a/timed/permissions.py
+++ b/timed/permissions.py
@@ -91,3 +91,10 @@ class IsSuperUser(BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)
+
+
+class IsNotTransferred(BasePermission):
+    """Allows access only to not transferred objects."""
+
+    def has_object_permission(self, request, view, obj):
+        return not obj.transferred

--- a/timed/tracking/tests/test_activity.py
+++ b/timed/tracking/tests/test_activity.py
@@ -237,12 +237,10 @@ def test_activity_not_editable(auth_client):
 def test_activity_retrievable_not_editable(auth_client):
     """Test that transferred activities are still retrievable."""
     activity = ActivityFactory.create(user=auth_client.user, transferred=True)
-    url = reverse('activity-list')
 
-    print('test')
+    url = reverse('activity-detail', args=[
+        activity.id
+    ])
+
     response = auth_client.get(url)
     assert response.status_code == status.HTTP_200_OK
-
-    json = response.json()
-    assert len(json['data']) == 1
-    assert json['data'][0]['id'] == str(activity.id)

--- a/timed/tracking/tests/test_activity.py
+++ b/timed/tracking/tests/test_activity.py
@@ -213,3 +213,36 @@ def test_activity_to_before_from(auth_client):
     assert json['errors'][0]['detail'] == (
         'An activity block may not end before it starts.'
     )
+
+
+def test_activity_not_editable(auth_client):
+    """Test that transferred activities are read only."""
+    activity = ActivityFactory.create(user=auth_client.user, transferred=True)
+
+    data = {
+        'data': {
+            'type': 'activities',
+            'id': activity.id,
+            'attributes': {
+                'comment': 'Changed Comment',
+            }
+        }
+    }
+
+    url = reverse('activity-detail', args=[activity.id])
+    response = auth_client.patch(url, data)
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_activity_retrievable_not_editable(auth_client):
+    """Test that transferred activities are still retrievable."""
+    activity = ActivityFactory.create(user=auth_client.user, transferred=True)
+    url = reverse('activity-list')
+
+    print('test')
+    response = auth_client.get(url)
+    assert response.status_code == status.HTTP_200_OK
+
+    json = response.json()
+    assert len(json['data']) == 1
+    assert json['data'][0]['id'] == str(activity.id)

--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -25,7 +25,8 @@ class ActivityViewSet(ModelViewSet):
     filterset_class     = filters.ActivityFilterSet
     permission_classes = [
         # users may not change transferred activities
-        C(IsAuthenticated) & C(IsNotTransferred)
+        C(IsAuthenticated) & C(IsNotTransferred) |
+        C(IsAuthenticated) & C(IsReadOnly)
     ]
 
     def get_queryset(self):

--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -11,8 +11,8 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from timed.permissions import (IsAuthenticated, IsDeleteOnly, IsOwner,
-                               IsReadOnly, IsReviewer, IsSuperUser,
+from timed.permissions import (IsAuthenticated, IsDeleteOnly, IsNotTransferred,
+                               IsOwner, IsReadOnly, IsReviewer, IsSuperUser,
                                IsSupervisor, IsUnverified)
 from timed.serializers import AggregateObject
 from timed.tracking import filters, models, serializers
@@ -23,6 +23,10 @@ class ActivityViewSet(ModelViewSet):
 
     serializer_class = serializers.ActivitySerializer
     filterset_class     = filters.ActivityFilterSet
+    permission_classes = [
+        # users may not change transferred activities
+        C(IsAuthenticated) & C(IsNotTransferred)
+    ]
 
     def get_queryset(self):
         """Filter the queryset by the user of the request.


### PR DESCRIPTION
Remove unnecessary activity field in reports and make activity read only if it has been transferred.