### PR TITLE
Remove obsolete ignore deprecation warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,7 +20,3 @@ filterwarnings =
     # TODO: replace rest_conditions with composable permission classes
     # https://www.django-rest-framework.org/community/3.9-announcement/#composable-permission-classes
     ignore:Using user\.is_authenticated\(\) and user\.is_anonymous\(\)
-
-    # ignore pytest-freezegun warning till following PR is released
-    # https://github.com/ktosiek/pytest-freezegun/pull/4
-    ignore:MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.


### PR DESCRIPTION
This was fixed in pytest-freezegun 0.3.0