### PR TITLE
Remove rest_condition for REST framework operators

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,8 +15,3 @@ filterwarnings =
 
     # TODO: adjust frontend for this change to work
     ignore:PageNumberPagination is deprecated. Use JsonApiPageNumberPagination instead.
-
-    # This warning is caused by rest_conditions
-    # TODO: replace rest_conditions with composable permission classes
-    # https://www.django-rest-framework.org/community/3.9-announcement/#composable-permission-classes
-    ignore:Using user\.is_authenticated\(\) and user\.is_anonymous\(\)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pyexcel-ods3==0.5.3
 pyexcel-xlsx==0.5.7
 pyexcel-ezodf==0.3.4
 django-environ==0.4.5
-rest_condition==1.0.3
 django-money==0.14.4
 python-redmine==2.2.0
 uwsgi==2.0.18

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "pyexcel-xlsx",
         "pyexcel-ezodf",
         "django-environ",
-        "rest_condition",
         "django-money",
         "python-redmine",
     ),

--- a/timed/employment/views.py
+++ b/timed/employment/views.py
@@ -5,7 +5,6 @@ from django.contrib.auth import get_user_model
 from django.db.models import CharField, DateField, IntegerField, Q, Value
 from django.db.models.functions import Concat
 from django.utils.translation import ugettext_lazy as _
-from rest_condition import C
 from rest_framework import exceptions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -37,13 +36,13 @@ class UserViewSet(ModelViewSet):
 
     permission_classes = [
         # only owner, superuser and supervisor may update user
-        (C(IsOwner) | C(IsSuperUser) | C(IsSupervisor)) & C(IsUpdateOnly)
+        (IsOwner | IsSuperUser | IsSupervisor) & IsUpdateOnly
         # only superuser may delete users without reports
-        | C(IsSuperUser) & C(IsDeleteOnly) & C(NoReports)
+        | IsSuperUser & IsDeleteOnly & NoReports
         # only superuser may create users
-        | C(IsSuperUser) & C(IsCreateOnly)
+        | IsSuperUser & IsCreateOnly
         # all authenticated users may read
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
 
     serializer_class = serializers.UserSerializer
@@ -263,9 +262,9 @@ class EmploymentViewSet(ModelViewSet):
     filterset_class = filters.EmploymentFilterSet
     permission_classes = [
         # super user can add/read overtime credits
-        C(IsAuthenticated) & C(IsSuperUser)
+        IsAuthenticated & IsSuperUser
         # user may only read filtered results
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
 
     def get_queryset(self):
@@ -327,9 +326,9 @@ class AbsenceCreditViewSet(ModelViewSet):
     serializer_class = serializers.AbsenceCreditSerializer
     permission_classes = [
         # super user can add/read absence credits
-        C(IsAuthenticated) & C(IsSuperUser)
+        IsAuthenticated & IsSuperUser
         # user may only read filtered results
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
 
     def get_queryset(self):
@@ -358,9 +357,9 @@ class OvertimeCreditViewSet(ModelViewSet):
     serializer_class = serializers.OvertimeCreditSerializer
     permission_classes = [
         # super user can add/read overtime credits
-        C(IsAuthenticated) & C(IsSuperUser)
+        IsAuthenticated & IsSuperUser
         # user may only read filtered results
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
 
     def get_queryset(self):

--- a/timed/permissions.py
+++ b/timed/permissions.py
@@ -28,6 +28,16 @@ class IsDeleteOnly(BasePermission):
         return self.has_permission(request, view)
 
 
+class IsNotDelete(BasePermission):
+    """Disallow delete method."""
+
+    def has_permission(self, request, view):
+        return request.method != "DELETE"
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_permission(request, view)
+
+
 class IsCreateOnly(BasePermission):
     """Allows only create method."""
 

--- a/timed/tracking/views.py
+++ b/timed/tracking/views.py
@@ -4,7 +4,6 @@ import django_excel
 from django.db.models import Q
 from django.http import HttpResponseBadRequest
 from django.utils.translation import ugettext_lazy as _
-from rest_condition import C
 from rest_framework import exceptions, status
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -12,7 +11,7 @@ from rest_framework.viewsets import ModelViewSet
 
 from timed.permissions import (
     IsAuthenticated,
-    IsDeleteOnly,
+    IsNotDelete,
     IsNotTransferred,
     IsOwner,
     IsReadOnly,
@@ -32,8 +31,8 @@ class ActivityViewSet(ModelViewSet):
     filterset_class = filters.ActivityFilterSet
     permission_classes = [
         # users may not change transferred activities
-        C(IsAuthenticated) & C(IsNotTransferred)
-        | C(IsAuthenticated) & C(IsReadOnly)
+        IsAuthenticated & IsNotTransferred
+        | IsAuthenticated & IsReadOnly
     ]
 
     def get_queryset(self):
@@ -71,14 +70,14 @@ class ReportViewSet(ModelViewSet):
     filterset_class = filters.ReportFilterSet
     permission_classes = [
         # superuser may edit all reports but not delete
-        C(IsSuperUser) & ~C(IsDeleteOnly)
+        IsSuperUser & IsNotDelete
         # reviewer and supervisor may change unverified reports
         # but not delete them
-        | (C(IsReviewer) | C(IsSupervisor)) & C(IsUnverified) & ~C(IsDeleteOnly)
+        | (IsReviewer | IsSupervisor) & IsUnverified & IsNotDelete
         # owner may only change its own unverified reports
-        | C(IsAuthenticated) & C(IsOwner) & C(IsUnverified)
+        | IsAuthenticated & IsOwner & IsUnverified
         # all authenticated users may read all reports
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
     ordering = ("date", "id")
     ordering_fields = (
@@ -258,11 +257,11 @@ class AbsenceViewSet(ModelViewSet):
 
     permission_classes = [
         # superuser can change all but not delete
-        C(IsAuthenticated) & C(IsSuperUser) & ~C(IsDeleteOnly)
+        IsAuthenticated & IsSuperUser & IsNotDelete
         # owner may change all its absences
-        | C(IsAuthenticated) & C(IsOwner)
+        | IsAuthenticated & IsOwner
         # all authenticated users may read filtered result
-        | C(IsAuthenticated) & C(IsReadOnly)
+        | IsAuthenticated & IsReadOnly
     ]
 
     def get_queryset(self):


### PR DESCRIPTION
Replace existing permission_classes composed using rest_condition
operator `C()` with native operators.
Introduce new Permission `IsNotDelete` as complement to `IsDeleteOnly`
because there's no negation allowed, only bitwise `&` and `|`.

Get rid of rest_condition dependency.