### PR TITLE
feat(tracking): configurable fields for changes mail

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -253,3 +253,10 @@ WORK_REPORT_PATH = env.str(
     "DJANGO_WORK_REPORT_PATH",
     default=resource_filename("timed.reports", "templates/workreport.ots"),
 )
+
+# Tracking: fields which should be included in email (when report was changed
+# during verification)
+TRACKING_REPORT_VERIFIED_CHANGES = env.list(
+    "DJANGO_TRACKING_REPORT_VERIFIED_CHANGES",
+    default=default(["task", "comment", "not_billable"]),
+)

--- a/timed/tracking/tasks.py
+++ b/timed/tracking/tasks.py
@@ -47,7 +47,7 @@ def _get_report_changeset(report, fields):
             for key in fields.keys()
             # skip if field is not changed or just a reviewer field
             if getattr(report, key) != fields[key]
-            and key not in ["review", "verified_by"]
+            and key in settings.TRACKING_REPORT_VERIFIED_CHANGES
         },
     }
     if not changeset["changes"]:


### PR DESCRIPTION
Make fields showing up in changed reports mail configurable
Default: ["task", "comment", "not_billable"]