### PR TITLE
Revert "Match postgres version with production"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: postgres:9.4
+    image: postgres:9.6
     ports:
       - 5432:5432
     volumes:


### PR DESCRIPTION
This reverts commit 923f8e23f2e1e30fd43d8ee09c6fbb0d18028013.
We don't want to use an EOL postgres version.
Also downgrading postgres is potentially dangerous, for example my
testsetup wasn't able to start because the db version wasn't supported
by the postgres 9.4 driver.