### PR TITLE
Performance fix for reports export

### DIFF
--- a/timed/locale/en/LC_MESSAGES/django.po
+++ b/timed/locale/en/LC_MESSAGES/django.po
@@ -7,24 +7,201 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-03-02 13:58+0100\n"
+"POT-Creation-Date: 2020-04-14 17:04+0200\n"
 "PO-Revision-Date: 2017-03-02 13:59+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Last-Translator: \n"
-"Language-Team: \n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: timed/employment/admin.py:35
+#: timed/employment/admin.py:23
+msgid "Supervisor"
+msgstr ""
+
+#: timed/employment/admin.py:24
+msgid "Supervisors"
+msgstr ""
+
+#: timed/employment/admin.py:31
+msgid "Supervisee"
+msgstr ""
+
+#: timed/employment/admin.py:32
+msgid "Supervisees"
+msgstr ""
+
+#: timed/employment/admin.py:38
+msgid "Worktime per day in hours"
+msgstr ""
+
+#: timed/employment/admin.py:58 timed/employment/serializers.py:248
 msgid "The end date must be after the start date"
 msgstr "The end date must be after the start date"
 
-#: timed/employment/admin.py:43
-msgid "A user can only have one active employment"
-msgstr "A user can only have one active employment"
-
-#: timed/employment/admin.py:58
+#: timed/employment/admin.py:68 timed/employment/serializers.py:262
 msgid "A user can't have multiple employments at the same time"
 msgstr "A user can't have multiple employments at the same time"
+
+#: timed/employment/admin.py:88 timed/subscription/admin.py:14
+msgid "Duration in hours"
+msgstr ""
+
+#: timed/employment/admin.py:124
+msgid "Extra fields"
+msgstr ""
+
+#: timed/employment/admin.py:129
+msgid "Disable selected users"
+msgstr ""
+
+#: timed/employment/admin.py:134
+msgid "Enable selected users"
+msgstr ""
+
+#: timed/employment/admin.py:139
+msgid "Disable staff status of selected users"
+msgstr ""
+
+#: timed/employment/admin.py:144
+msgid "Enable staff status of selected users"
+msgstr ""
+
+#: timed/employment/models.py:347
+msgid "last name"
+msgstr ""
+
+#: timed/employment/views.py:87 timed/employment/views.py:99
+#, python-format
+msgid "Transfer %(year)s"
+msgstr ""
+
+#: timed/employment/views.py:138 timed/employment/views.py:197
+msgid "Date is invalid"
+msgstr ""
+
+#: timed/employment/views.py:141 timed/employment/views.py:199
+msgid "Date filter needs to be set"
+msgstr ""
+
+#: timed/employment/views.py:225
+msgid "User filter needs to be set"
+msgstr ""
+
+#: timed/employment/views.py:233
+msgid "User is invalid"
+msgstr ""
+
+#: timed/forms.py:31
+msgid "Enter a datetime.timedelta"
+msgstr ""
+
+#: timed/models.py:17
+msgid "Monday"
+msgstr ""
+
+#: timed/models.py:18
+msgid "Tuesday"
+msgstr ""
+
+#: timed/models.py:19
+msgid "Wednesday"
+msgstr ""
+
+#: timed/models.py:20
+msgid "Thursday"
+msgstr ""
+
+#: timed/models.py:21
+msgid "Friday"
+msgstr ""
+
+#: timed/models.py:22
+msgid "Saturday"
+msgstr ""
+
+#: timed/models.py:23
+msgid "Sunday"
+msgstr ""
+
+#: timed/projects/admin.py:47 timed/projects/admin.py:94
+msgid "Estimated time in hours"
+msgstr ""
+
+#: timed/projects/admin.py:87
+msgid "Reviewer"
+msgstr ""
+
+#: timed/projects/admin.py:88
+msgid "Reviewers"
+msgstr ""
+
+#: timed/subscription/models.py:54
+msgid "password"
+msgstr ""
+
+#: timed/tracking/serializers.py:47
+#, fuzzy
+#| msgid "A user can only have one active employment"
+msgid "A user can only have one active activity"
+msgstr "A user can only have one active employment"
+
+#: timed/tracking/serializers.py:60
+msgid "An activity block may not end before it starts."
+msgstr ""
+
+#: timed/tracking/serializers.py:108
+#, python-brace-format
+msgid "Only owner may change {field}"
+msgstr ""
+
+#: timed/tracking/serializers.py:140
+msgid "Only reviewer may verify reports."
+msgstr ""
+
+#: timed/tracking/serializers.py:143
+msgid "You may only verifiy with your own user"
+msgstr ""
+
+#: timed/tracking/serializers.py:147
+msgid "Report can't both be set as `review` and `verified`."
+msgstr ""
+
+#: timed/tracking/serializers.py:294
+msgid "Only owner may change date"
+msgstr ""
+
+#: timed/tracking/serializers.py:304
+msgid "Only owner may change absence type"
+msgstr ""
+
+#: timed/tracking/serializers.py:322
+msgid "You can't create an absence on an unemployed day."
+msgstr ""
+
+#: timed/tracking/serializers.py:328
+msgid "You can't create an absence on a public holiday"
+msgstr ""
+
+#: timed/tracking/serializers.py:332
+msgid "You can't create an absence on a weekend"
+msgstr ""
+
+#: timed/tracking/views.py:176
+msgid "Editable filter needs to be set for bulk update"
+msgstr ""
+
+#: timed/tracking/views.py:185
+msgid "Reviewer filter needs to be set to verifying user"
+msgstr ""
+
+#: timed/tracking/views.py:196
+msgid "Reports can't both be set as `review` and `verified`."
+msgstr ""
+
+#: timed/tracking/views.py:244
+#, python-brace-format
+msgid "Your request exceeds the maximum allowed entries ({0} > {1})"
+msgstr ""

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -258,6 +258,8 @@ WORK_REPORTS_EXPORT_MAX_COUNT = env.int(
     "DJANGO_WORK_REPORTS_EXPORT_MAX_COUNT", default=0
 )
 
+REPORTS_EXPORT_MAX_COUNT = env.int("DJANGO_REPORTS_EXPORT_MAX_COUNT", default=0)
+
 # Tracking: Report fields which should be included in email (when report was
 # changed during verification)
 TRACKING_REPORT_VERIFIED_CHANGES = env.list(


### PR DESCRIPTION
Make sure that reports-export does not crash.
Add the settings REPORTS_EXPORT_MAX_COUNT to optionally restrict
queryset to a certain length.
Move cost_center and billing_type logic to query annotations to make it
more performant.
Return to-be-exported list a generator expression to not fill up memory.

This also includes a fix where the cost center name used the
task.project.name instead of task.cost_center.name.