### PR TITLE
chore: move to psycopg2 wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN wget https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for
 RUN apt-get update && apt-get install -y --no-install-recommends \
   libldap2-dev \
   libsasl2-dev \
+  libpq-dev \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-multiselectfield==0.1.12
 djangorestframework==3.11.0
 djangorestframework-simplejwt==4.4.0
 djangorestframework-jsonapi[django-filter]==3.1.0
-psycopg2-binary==2.8.4
+psycopg2==2.8.4
 pytz==2019.3
 pyexcel-webio==0.1.4
 pyexcel-io==0.5.20


### PR DESCRIPTION
The psycopg2-bin package is intended for getting a dev setup running
quickly, but not for production use.
See: https://www.psycopg.org/docs/install.html#binary-install-from-pypi