### PR TITLE
feat: add setting to restrict work reports export size

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -254,6 +254,10 @@ WORK_REPORT_PATH = env.str(
     default=resource_filename("timed.reports", "templates/workreport.ots"),
 )
 
+WORK_REPORTS_EXPORT_MAX_COUNT = env.int(
+    "DJANGO_WORK_REPORTS_EXPORT_MAX_COUNT", default=0
+)
+
 # Tracking: Report fields which should be included in email (when report was
 # changed during verification)
 TRACKING_REPORT_VERIFIED_CHANGES = env.list(


### PR DESCRIPTION
The `WORK_REPORTS_EXPORT_MAX_COUNT` setting restricts work reports
export to the given count. This should fix cases where the (unfiltered)
queryset is too big to handle.