### PR TITLE
fix(admin): use django-money as installed app

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -60,6 +60,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "rest_framework",
     "django_filters",
+    "djmoney",
     "timed.employment",
     "timed.projects",
     "timed.tracking",


### PR DESCRIPTION
Somehow it got overlooked that django-money requires the "djmoney" entry
in INSTALLED_APPS to be present. This causes the admin rendering to use
django-money specific code instead of treating the values as simple
decimals.

See: https://github.com/django-money/django-money/issues/232