### PR TITLE
Only show not verified reports

### DIFF
--- a/timed/reports/templates/mail/notify_reviewers_unverified.txt
+++ b/timed/reports/templates/mail/notify_reviewers_unverified.txt
@@ -2,4 +2,4 @@ There are unverified reports which need your attention.
 
 {{message}}
 
-Go to <{{protocol}}://{{domain}}/analysis?fromDate={{start}}&toDate={{end}}&reviewer={{reviewer.id}}&editable=1>
+Go to <{{protocol}}://{{domain}}/analysis?fromDate={{start}}&toDate={{end}}&reviewer={{reviewer.id}}&editable=1&verified=0>


### PR DESCRIPTION
Change the URL to filter only for reports that are not yet verified.