### PR TITLE
chore: revert updating django from 3.1.7 to 3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-dateutil==2.8.1
-django==3.2
+django==3.1.7
 # might remove this once we find out how the jsonapi extras_require work
 django-filter==2.4.0
 django-multiselectfield==0.1.12


### PR DESCRIPTION
Reverts adfinis-sygroup/timed-backend#707

That one went in too fast