### PR TITLE
feat: export metrics with django-prometheus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build the project
         run: |
+          echo "ENV=dev" > .env
           docker-compose up -d --build backend
           docker-compose exec -T backend pip install -r requirements-dev.txt
       - name: Lint the code

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,7 @@ RUN pip install --upgrade --no-cache-dir --requirement $REQUIREMENTS --disable-p
 
 COPY . /app
 
-RUN mkdir -p /var/www/static \
-  && ENV=docker ./manage.py collectstatic --noinput
+RUN mkdir -p /var/www/static
 
 EXPOSE 80
 CMD ./cmd.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help start test shell loaddata
+.PHONY: help start stop test shell flush loaddata
 .DEFAULT_GOAL := help
 
 help:
@@ -6,13 +6,18 @@ help:
 
 start: ## Start the development server
 	@docker-compose up -d --build
-	@make loaddata
+
+stop: ## Stop the development server
+	@docker-compose stop
 
 test: ## Test the project
-	@docker-compose exec backend sh -c "black --check . && flake8 && pytest --no-cov-on-fail --cov --create-db"
+	@docker-compose exec backend sh -c "black --check . && flake8 && pytest --no-cov-on-fail --cov"
 
 shell: ## Shell into the backend
 	@docker-compose exec backend bash
 
-loaddata: ## Loads test data into the database
+flush: ## Flush database contents
+	@docker-compose exec backend ./manage.py flush --no-input
+
+loaddata: flush ## Loads test data into the database
 	@docker-compose exec backend ./manage.py loaddata timed/fixtures/test_data.json

--- a/cmd.sh
+++ b/cmd.sh
@@ -5,4 +5,7 @@ sed -i \
     -e 's/harakiri = .*/harakiri = '"${UWSGI_HARAKIRI}"'/g' "${UWSGI_INI}" \
     -e 's/processes = .*/processes = '"${UWSGI_PROCESSES}"'/g' "${UWSGI_INI}"
 
-wait-for-it.sh "${DJANGO_DATABASE_HOST}":"${DJANGO_DATABASE_PORT}" -t "${WAITFORIT_TIMEOUT}" -- ./manage.py migrate --no-input && uwsgi
+wait-for-it.sh "${DJANGO_DATABASE_HOST}":"${DJANGO_DATABASE_PORT}" -t "${WAITFORIT_TIMEOUT}" -- \
+    ./manage.py migrate --no-input && \
+    ./manage.py collectstatic --noinput && \
+    uwsgi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     environment:
       - DJANGO_DATABASE_HOST=db
       - DJANGO_DATABASE_PORT=5432
-      - ENV=docker
       - STATIC_ROOT=/var/www/static
     networks:
       - timed.local

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ django==3.1.7
 # might remove this once we find out how the jsonapi extras_require work
 django-filter==2.4.0
 django-multiselectfield==0.1.12
+django-prometheus==2.1.0
 djangorestframework==3.12.4
 djangorestframework-jsonapi[django-filter]==3.1.0
 mozilla-django-oidc==1.2.4

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -27,7 +27,7 @@ def default(default_dev=env.NOTSET, default_prod=env.NOTSET):
 DATABASES = {
     "default": {
         "ENGINE": env.str(
-            "DJANGO_DATABASE_ENGINE", default="django.db.backends.postgresql"
+            "DJANGO_DATABASE_ENGINE", default="django_prometheus.db.backends.postgresql"
         ),
         "NAME": env.str("DJANGO_DATABASE_NAME", default="timed"),
         "USER": env.str("DJANGO_DATABASE_USER", default="timed"),
@@ -61,6 +61,7 @@ INSTALLED_APPS = [
     "django_filters",
     "djmoney",
     "mozilla_django_oidc",
+    "django_prometheus",
     "timed.employment",
     "timed.projects",
     "timed.tracking",
@@ -70,6 +71,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -77,6 +79,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "timed.urls"
@@ -148,7 +151,8 @@ STATIC_ROOT = env.str("STATIC_ROOT", None)
 CACHES = {
     "default": {
         "BACKEND": env.str(
-            "CACHE_BACKEND", default="django.core.cache.backends.locmem.LocMemCache"
+            "CACHE_BACKEND",
+            default="django_prometheus.cache.backends.locmem.LocMemCache",
         ),
         "LOCATION": env.str("CACHE_LOCATION", ""),
     }

--- a/timed/urls.py
+++ b/timed/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     re_path(r"^api/v1/", include("timed.reports.urls")),
     re_path(r"^api/v1/", include("timed.subscription.urls")),
     re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
+    re_path(r"^prometheus/", include("django_prometheus.urls")),
 ]


### PR DESCRIPTION
~~Note that currently the url `/prometheus/metrics` requires authentication. This can be setup using a confidential client given in the documentation.~~

~~Auth-free metrics is out of scope for the moment.~~

Edit: disregard above note, metrics can be scrapped from `/prometheus/metrics` without authentication.