### PR TITLE
fix(runtime): use gunicorn instead of uwsgi

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ according to type.
 | `DJANGO_SERVER_EMAIL`                        | Email address error messages are sent from                                               | root@localhost                                               |
 | `DJANGO_ADMINS`                              | List of people who get error notifications                                               | not set                                                      |
 | `DJANGO_WORK_REPORT_PATH`                    | Path of custom work report template                                                      | not set                                                      |
-| `UWSGI_INI`                                  | Path to uwsgi.ini configuration                                                          | /app/uwsgi.ini                                               |
-| `UWSGI_MAX_REQUESTS`                         | uWSGI max requests                                                                       | 2000                                                         |
-| `UWSGI_HARAKIRI`                             | uWSGI harakiri (request timeout)                                                         | 5                                                            |
-| `UWSGI_PROCESSES`                            | uWSGI number of processes                                                                | 4                                                            |
+| `GUNICORN_WORKERS`                           | Number of worker processes to use                                                        | 8                                                            |
+| `GUNICORN_CMD_ARGS`                          | [Additional args for gunicorn](https://docs.gunicorn.org/en/latest/configure.html)       | not set                                                      |
+| `STATIC_ROOT`                                | Path to the static files. In prod, you may want to mount a docker volume here, so it can be served by nginx | `/app/static`                             |
+| `STATIC_URL`                                 | URL path to the static files on the web server. Configure nginx to point this to `$STATIC_ROOT`   | `/static`                                                    |
 
 
 ## Contributing

--- a/cmd.sh
+++ b/cmd.sh
@@ -1,11 +1,8 @@
 #!/bin/sh
 
-sed -i \
-    -e 's/max-requests = .*/max-requests = '"${UWSGI_MAX_REQUESTS}"'/g' "${UWSGI_INI}" \
-    -e 's/harakiri = .*/harakiri = '"${UWSGI_HARAKIRI}"'/g' "${UWSGI_INI}" \
-    -e 's/processes = .*/processes = '"${UWSGI_PROCESSES}"'/g' "${UWSGI_INI}"
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-8}"
 
 wait-for-it.sh "${DJANGO_DATABASE_HOST}":"${DJANGO_DATABASE_PORT}" -t "${WAITFORIT_TIMEOUT}" -- \
     ./manage.py migrate --no-input && \
     ./manage.py collectstatic --noinput && \
-    uwsgi
+    gunicorn --workers=$GUNICORN_WORKERS --bind=0.0.0.0:80 timed.wsgi:application

--- a/cmd.sh
+++ b/cmd.sh
@@ -2,7 +2,8 @@
 
 GUNICORN_WORKERS="${GUNICORN_WORKERS:-8}"
 
+./manage.py collectstatic --noinput
+
 wait-for-it.sh "${DJANGO_DATABASE_HOST}":"${DJANGO_DATABASE_PORT}" -t "${WAITFORIT_TIMEOUT}" -- \
     ./manage.py migrate --no-input && \
-    ./manage.py collectstatic --noinput && \
     gunicorn --workers=$GUNICORN_WORKERS --bind=0.0.0.0:80 timed.wsgi:application

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ pyexcel-ezodf==0.3.4
 django-environ==0.4.5
 django-money==1.3.1
 python-redmine==2.3.0
-uwsgi==2.0.19.1
+gunicorn==20.1.0

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -144,7 +144,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
 STATIC_URL = env.str("STATIC_URL", "/static/")
-STATIC_ROOT = env.str("STATIC_ROOT", None)
+STATIC_ROOT = env.str("STATIC_ROOT", "/app/static")
 
 # Cache
 


### PR DESCRIPTION
Also, use 8 workers by default instead of 4.

This is partly experimental, and partly due to us having tons of performance problems on prod, which could very well be due to the poor UWSGI config.