### PR TITLE
feat(deployment): serve static files

### DIFF
--- a/timed/urls.py
+++ b/timed/urls.py
@@ -1,5 +1,7 @@
 """Root URL mapping."""
 
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, re_path
 
@@ -12,4 +14,4 @@ urlpatterns = [
     re_path(r"^api/v1/", include("timed.subscription.urls")),
     re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
     re_path(r"^prometheus/", include("django_prometheus.urls")),
-]
+] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
This is against django best practices, but this is mainly a DRF application,
and the only static files we serve are for the Django-Admin, with a limited
user base. Thus, we can serve static files without too much negative impact