### PR TITLE
fix(projects): add manager role to project assignees

### DIFF
--- a/timed/projects/migrations/0012_migrate_reviewers_to_assignees.py
+++ b/timed/projects/migrations/0012_migrate_reviewers_to_assignees.py
@@ -10,7 +10,7 @@ def migrate_reviewers(apps, schema_editor):
     for project in projects:
         for reviewer in project.reviewers.all():
             project_assignee = ProjectAssignee(
-                user=reviewer, project=project, is_reviewer=True
+                user=reviewer, project=project, is_reviewer=True, is_manager=True
             )
             project_assignee.save()
 


### PR DESCRIPTION
Until the introduction of assignees, a reviewer could verify
reports and manage tasks of a project. Now, this has changed and
tasks can only be managed by assignees who have the manager role.