### PR TITLE
fix: use whitenoise middleware to host admin statics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ django-money==1.3.1
 python-redmine==2.3.0
 sentry-sdk==1.0.0
 gunicorn==20.1.0
+whitenoise==5.3.0

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -83,6 +83,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_prometheus.middleware.PrometheusAfterMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
 ]
 
 ROOT_URLCONF = "timed.urls"

--- a/timed/urls.py
+++ b/timed/urls.py
@@ -1,7 +1,5 @@
 """Root URL mapping."""
 
-from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, re_path
 
@@ -14,4 +12,4 @@ urlpatterns = [
     re_path(r"^api/v1/", include("timed.subscription.urls")),
     re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
     re_path(r"^prometheus/", include("django_prometheus.urls")),
-] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+]


### PR DESCRIPTION
- Use whitenoise to host static files.

Fixes #776 
Fixes https://github.com/adfinis-sygroup/timed-backend-static/issues/2