### PR TITLE
fix(tracking): set correct value for billed flag on reports

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 black==21.6b0
 coverage==5.5
-factory-boy==3.2.0
+factory-boy==3.2.1
 flake8==3.9.2
 flake8-blind-except==0.2.0
 flake8-debugger==4.0.0

--- a/timed/permissions.py
+++ b/timed/permissions.py
@@ -161,13 +161,6 @@ class IsNotTransferred(BasePermission):
         return not obj.transferred
 
 
-class IsNotBilledOrVerified(BasePermission):
-    """Allows access only to not billed or not verfied objects."""
-
-    def has_object_permission(self, request, view, obj):
-        return not obj.billed or obj.verified_by_id is None
-
-
 class IsInternal(IsAuthenticated):
     """Allows access only to internal employees."""
 

--- a/timed/projects/tests/test_project.py
+++ b/timed/projects/tests/test_project.py
@@ -146,3 +146,21 @@ def test_project_filter(internal_employee_client):
 
     json = response.json()
     assert len(json["data"]) == 1
+
+
+def test_project_update_billed_flag(internal_employee_client, report_factory):
+    report = report_factory.create()
+    project = report.task.project
+    assert not report.billed
+
+    project.billed = True
+    project.save()
+
+    report.refresh_from_db()
+    assert report.billed
+
+    project.billed = False
+    project.save()
+
+    report.refresh_from_db()
+    assert not report.billed

--- a/timed/tracking/serializers.py
+++ b/timed/tracking/serializers.py
@@ -169,8 +169,15 @@ class ReportSerializer(TotalTimeRootMetaMixin, ModelSerializer):
         if not user.is_accountant and billed:
             raise ValidationError(_("Only accountants may bill reports."))
 
+        # update billed flag on created reports
         if not self.instance or billed is None:
             data["billed"] = task.project.billed
+
+        # update billed flag on reports that are being moved to a different project
+        # according to the billed flag of the project the report was moved to
+        if self.instance and data.get("task"):
+            if self.instance.task.id != data.get("task").id:
+                data["billed"] = data.get("task").project.billed
 
         current_employment = Employment.objects.get_at(user=user, date=date.today())
 

--- a/timed/tracking/tests/snapshots/snap_test_report.py
+++ b/timed/tracking/tests/snapshots/snap_test_report.py
@@ -15,20 +15,35 @@ Some of your reports have been changed.
 Reviewer: Test User
 
 
-Date: 06/27/1970
+Date: 10/03/1998
+Duration: 3:15 (h:mm)
+
+
+
+* Task
+  [old] Allen Inc > Cross-platform content-based synergy > and Sons
+  [new] Allen Inc > Cross-platform content-based synergy > LLC
+
+* Comment
+  [old] foo
+  [new] some other comment
+
+---
+
+Date: 05/27/2000
 Duration: 2:30 (h:mm)
 
 Comment: some other comment
 
 * Task
-  [old] Allen Inc > Cross-platform content-based synergy > and Sons
-  [new] Allen Inc > Cross-platform content-based synergy > Group
+  [old] Allen Inc > Cross-platform content-based synergy > Ltd
+  [new] Allen Inc > Cross-platform content-based synergy > LLC
 
 ---
 
-Date: 11/02/1975
+Date: 04/20/2005
 Duration: 0:15 (h:mm)
-Task: Allen Inc > Cross-platform content-based synergy > Group
+Task: Allen Inc > Cross-platform content-based synergy > LLC
 Comment: some other comment
 
 * Not_Billable
@@ -37,24 +52,9 @@ Comment: some other comment
 
 ---
 
-Date: 05/14/1976
-Duration: 3:15 (h:mm)
-
-
-
-* Task
-  [old] Allen Inc > Cross-platform content-based synergy > Ltd
-  [new] Allen Inc > Cross-platform content-based synergy > Group
-
-* Comment
-  [old] foo
-  [new] some other comment
-
----
-
-Date: 04/20/2005
+Date: 03/23/2016
 Duration: 1:00 (h:mm)
-Task: Allen Inc > Cross-platform content-based synergy > Group
+Task: Allen Inc > Cross-platform content-based synergy > LLC
 
 
 * Comment


### PR DESCRIPTION
Use project's billed flag on new reports (e.g. when a project was paid in advance).
If a report is moved to a different project, task or customer, set the billed flag on the report according to the project the report was moved to.
Removed IsNotBilledOrVerified permission.
Tests for the billed flag are already implemented.

Following needs clarification with the admin:
- [x]  Setting the billed flag on reports to false on already billed projects. Should it be allowed or not?
- [x] What should happen with the reports, if a project is set from billed to not billed? As of now, the reports will only be updated, if anything is changed on them (by manually saving a report).


