### PR TITLE
feat(settings): add DATA_UPLOAD_MAX_NUMBER_FIELDS to env

### DIFF
--- a/timed/settings.py
+++ b/timed/settings.py
@@ -357,3 +357,6 @@ if env.str("DJANGO_SENTRY_DSN", default=""):  # pragma: no cover
     )
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+DATA_UPLOAD_MAX_NUMBER_FIELDS = env.int(
+    "DJANGO_DATA_UPLOAD_MAX_NUMBER_FIELDS", default=1000
+)


### PR DESCRIPTION
This value should be customizable as there are big projects that have a lot of tasks, tasks and project assignees. In these cases the amount of fields exceeds the default value of 1000, which makes saving any changes on that project impossible.
I'll add the variable to our helm chart as well, so we can change it at any time.