### PR TITLE
feat(settings): add CORS_ALLOWED_ORIGINS to env

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 python-dateutil==2.8.1
 django==3.1.7
 # might remove this once we find out how the jsonapi extras_require work
+django-cors-headers==3.10.1
 django-filter==2.4.0
 django-multiselectfield==0.1.12
 django-prometheus==2.1.0

--- a/timed/settings.py
+++ b/timed/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "djmoney",
     "mozilla_django_oidc",
     "django_prometheus",
+    "corsheaders",
     "nested_inline",
     "timed.employment",
     "timed.projects",
@@ -75,6 +76,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -364,3 +366,4 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 DATA_UPLOAD_MAX_NUMBER_FIELDS = env.int(
     "DJANGO_DATA_UPLOAD_MAX_NUMBER_FIELDS", default=1000
 )
+CORS_ALLOWED_ORIGINS = env.list("DJANGO_CORS_ALLOWED_ORIGINS", default=[])


### PR DESCRIPTION
Customer Center needs to make requests to timed so we have to allow CORS from some domains that we can configure.