### PR TITLE
fix(filters): make date filter on employments work across timezones

### DIFF
--- a/timed/employment/filters.py
+++ b/timed/employment/filters.py
@@ -1,7 +1,4 @@
-from datetime import date
-
-from django.db.models import Value
-from django.db.models.functions import Coalesce
+from django.db.models import Q
 from django_filters.constants import EMPTY_VALUES
 from django_filters.rest_framework import DateFilter, Filter, FilterSet, NumberFilter
 
@@ -75,9 +72,11 @@ class EmploymentFilterSet(FilterSet):
     date = DateFilter(method="filter_date")
 
     def filter_date(self, queryset, name, value):
-        queryset = queryset.annotate(end=Coalesce("end_date", Value(date.today())))
 
-        queryset = queryset.filter(start_date__lte=value, end__gte=value)
+        queryset = queryset.filter(
+            Q(start_date__lte=value)
+            & Q(Q(end_date__gte=value) | Q(end_date__isnull=True))
+        )
 
         return queryset
 


### PR DESCRIPTION
The date filter on the employments assumed that an unbounded employment
ends today, to simplify the generated SQL. However, this breaks when
the user is ahead of the server's timezone (for example, a user in
Australia requests his employment as of 2021-12-28, where in the server's
UTC timezone, it's still 2021-12-27 - the user won't receive an employment)

The filter now correctly checks that either the employment is ending
today or later, or is explicitly unbounded.