### PR TITLE
chore(ci): fix building on legacy default branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,9 @@ name: Release Container Image
 on:
   pull_request:
   push:
-    branches: main
+    branches:
+      - main
+      - master
     tags:
       - 'v*.*.*'
 


### PR DESCRIPTION
I also created #872 for tracking the fact that we should move to the new default anyway